### PR TITLE
fix(deps): upgrade fastmcp from pinned git commit to >=3.2.0 PyPI release

### DIFF
--- a/mcp_servers/calendar/pyproject.toml
+++ b/mcp_servers/calendar/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -72,5 +72,4 @@ ignore = [
 
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/calendar/scripts/extract_tools.py
+++ b/mcp_servers/calendar/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters

--- a/mcp_servers/chat/pyproject.toml
+++ b/mcp_servers/chat/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -71,5 +71,4 @@ ignore = [
 
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/chat/scripts/extract_tools.py
+++ b/mcp_servers/chat/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters

--- a/mcp_servers/code/mcp_servers/code_execution_server/main.py
+++ b/mcp_servers/code/mcp_servers/code_execution_server/main.py
@@ -30,7 +30,7 @@ mcp.tool(code_exec)
 
 
 async def _flatten_tool_schemas():
-    for tool in (await mcp.get_tools()).values():
+    for tool in await mcp.list_tools():
         if getattr(tool, "parameters", None):
             tool.parameters = flatten_schema(tool.parameters)
 

--- a/mcp_servers/code/pyproject.toml
+++ b/mcp_servers/code/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -118,5 +118,4 @@ ignore = [
 ]
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/code/scripts/extract_tools.py
+++ b/mcp_servers/code/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters

--- a/mcp_servers/documents/mcp_servers/docs_server/main.py
+++ b/mcp_servers/documents/mcp_servers/docs_server/main.py
@@ -84,7 +84,7 @@ else:
 
 async def _flatten_tool_schemas():
     """Flatten all registered tool parameter schemas for runtime compatibility."""
-    for tool in (await mcp.get_tools()).values():
+    for tool in await mcp.list_tools():
         params = getattr(tool, "parameters", None)
         if isinstance(params, dict):
             tool.parameters = flatten_schema(params)

--- a/mcp_servers/documents/pyproject.toml
+++ b/mcp_servers/documents/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -90,5 +90,4 @@ ignore = [
 per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/documents/scripts/extract_tools.py
+++ b/mcp_servers/documents/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters

--- a/mcp_servers/filesystem/mcp_servers/filesystem_server/main.py
+++ b/mcp_servers/filesystem/mcp_servers/filesystem_server/main.py
@@ -34,7 +34,7 @@ mcp.tool(get_directory_tree)
 
 
 async def _flatten_tool_schemas():
-    for tool in (await mcp.get_tools()).values():
+    for tool in await mcp.list_tools():
         if getattr(tool, "parameters", None):
             tool.parameters = flatten_schema(tool.parameters)
 

--- a/mcp_servers/filesystem/pyproject.toml
+++ b/mcp_servers/filesystem/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -92,5 +92,4 @@ ignore = [
 
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/filesystem/scripts/extract_tools.py
+++ b/mcp_servers/filesystem/scripts/extract_tools.py
@@ -10,9 +10,9 @@ from main import mcp  # noqa: E402
 
 
 async def main():
-    tools = await mcp.get_tools()
+    tools = await mcp.list_tools()
     result = []
-    for tool in tools.values():
+    for tool in tools:
         entry = {"name": tool.name, "description": tool.description or ""}
         if hasattr(tool, "parameters") and tool.parameters:
             entry["inputSchema"] = tool.parameters

--- a/mcp_servers/mail/pyproject.toml
+++ b/mcp_servers/mail/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -83,5 +83,4 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/mail/scripts/extract_tools.py
+++ b/mcp_servers/mail/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters

--- a/mcp_servers/pdfs/mcp_servers/pdf_server/main.py
+++ b/mcp_servers/pdfs/mcp_servers/pdf_server/main.py
@@ -62,7 +62,7 @@ else:
 
 
 async def _flatten_tool_schemas():
-    for tool in (await mcp.get_tools()).values():
+    for tool in await mcp.list_tools():
         if getattr(tool, "parameters", None):
             tool.parameters = flatten_schema(tool.parameters)
 

--- a/mcp_servers/pdfs/pyproject.toml
+++ b/mcp_servers/pdfs/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -64,5 +64,4 @@ ignore = [
 per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/pdfs/scripts/extract_tools.py
+++ b/mcp_servers/pdfs/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters

--- a/mcp_servers/presentations/pyproject.toml
+++ b/mcp_servers/presentations/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -70,5 +70,4 @@ ignore = [
 per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/presentations/scripts/extract_tools.py
+++ b/mcp_servers/presentations/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters

--- a/mcp_servers/spreadsheets/mcp_servers/sheets_server/main.py
+++ b/mcp_servers/spreadsheets/mcp_servers/sheets_server/main.py
@@ -77,7 +77,7 @@ else:
 
 async def _flatten_tool_schemas():
     """Flatten all registered tool parameter schemas for runtime compatibility."""
-    for tool in (await mcp.get_tools()).values():
+    for tool in await mcp.list_tools():
         params = getattr(tool, "parameters", None)
         if isinstance(params, dict):
             tool.parameters = flatten_schema(params)

--- a/mcp_servers/spreadsheets/pyproject.toml
+++ b/mcp_servers/spreadsheets/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "asyncer>=0.0.9",
     "asyncpg>=0.30.0",
     "datadog-api-client>=2.44.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.27.0",
     "litellm>=1.77.7",
     "loguru>=0.7.3",
@@ -61,5 +61,4 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 
 [tool.uv.sources]
-fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }
 mcp-schema = { path = "packages/mcp_schema" }

--- a/mcp_servers/spreadsheets/scripts/extract_tools.py
+++ b/mcp_servers/spreadsheets/scripts/extract_tools.py
@@ -76,9 +76,9 @@ async def extract_from_server(server_path: str):
         mcp_instance = main.mcp
 
         # Extract tools
-        tools = await mcp_instance.get_tools()
+        tools = await mcp_instance.list_tools()
         server_tools = []
-        for tool in tools.values():
+        for tool in tools:
             entry = {"name": tool.name, "description": tool.description or ""}
             if hasattr(tool, "parameters") and tool.parameters:
                 entry["inputSchema"] = tool.parameters


### PR DESCRIPTION
## Summary

- Upgrade fastmcp from pinned git commit (`bc2f601`, pre-release 2.14.4.dev2) to `>=3.2.0` PyPI release across all 9 MCP servers
- Fix `get_tools()` → `list_tools()` API change in 5 servers that use tool schema flattening
- Remove `[tool.uv.sources]` git pin entries for fastmcp

## Root cause

The fastmcp git pin (`bc2f601`) depends on `docket` → `fakeredis`. `fakeredis` 2.35.0 renamed `FakeConnection`, causing all MCP servers to crash on startup with:

```
ImportError: cannot import name 'FakeConnection' from 'fakeredis.aioredis'
```

Rather than pinning fakeredis, this upgrades to the stable fastmcp 3.2.0 PyPI release which doesn't have the docket/fakeredis dependency.

## Changes

**pyproject.toml (9 files):**
- `fastmcp>=2.12.4` → `fastmcp>=3.2.0` in dependencies
- Removed `fastmcp = { git = "https://github.com/jlowin/fastmcp.git", rev = "bc2f601" }` from `[tool.uv.sources]`

**main.py (5 files):**
- `(await mcp.get_tools()).values()` → `await mcp.list_tools()` (API renamed in fastmcp 3.x)
- Affected servers: filesystem, documents, spreadsheets, pdfs, code

## Test plan

- [x] All 6 MCP servers used by downstream tests verified locally in Docker containers:
  - ✓ filesystem (15s, 6 tools)
  - ✓ documents (25s)
  - ✓ spreadsheets (15s)
  - ✓ presentations (19s)
  - ✓ pdfs (19s)
  - ✓ code (67s)
- [x] 6/6 servers start successfully and register tools with the MCP gateway