### PR TITLE
fix: pin fakeredis<2.27, fix simple_task MCP config, detect image format from magic bytes

### DIFF
--- a/examples/simple_task/mcp_config.json
+++ b/examples/simple_task/mcp_config.json
@@ -2,14 +2,17 @@
   "mcpServers": {
     "filesystem_server": {
       "transport": "stdio",
-      "command": "python",
+      "command": "uv",
       "args": [
+        "run",
+        "python",
         "main.py"
       ],
       "cwd": "/app/mcp_servers/filesystem/mcp_servers/filesystem_server",
       "env": {
         "APP_FS_ROOT": "/filesystem",
-        "SERVER_NAME": "filesystem_server"
+        "SERVER_NAME": "filesystem_server",
+        "MCP_TRANSPORT": "stdio"
       }
     }
   }

--- a/mcp_servers/calendar/pyproject.toml
+++ b/mcp_servers/calendar/pyproject.toml
@@ -73,3 +73,6 @@ ignore = [
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/chat/pyproject.toml
+++ b/mcp_servers/chat/pyproject.toml
@@ -72,3 +72,6 @@ ignore = [
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/code/pyproject.toml
+++ b/mcp_servers/code/pyproject.toml
@@ -119,3 +119,6 @@ ignore = [
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/documents/pyproject.toml
+++ b/mcp_servers/documents/pyproject.toml
@@ -91,3 +91,6 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/filesystem/mcp_servers/filesystem_server/tools/read_image_file.py
+++ b/mcp_servers/filesystem/mcp_servers/filesystem_server/tools/read_image_file.py
@@ -70,14 +70,25 @@ def read_image_file(
         with open(real_path, "rb") as f:
             image_data = f.read()
 
-        # Determine image format
-        image_format = {
-            "png": "png",
-            "jpg": "jpeg",
-            "jpeg": "jpeg",
-            "gif": "gif",
-            "webp": "webp",
-        }[file_ext]
+        # Detect actual image format from file header (magic bytes) rather than
+        # the extension, since mismatches cause LLM API rejections.
+        if image_data[:8] == b"\x89PNG\r\n\x1a\n":
+            image_format = "png"
+        elif image_data[:3] == b"\xff\xd8\xff":
+            image_format = "jpeg"
+        elif image_data[:6] in (b"GIF87a", b"GIF89a"):
+            image_format = "gif"
+        elif len(image_data) >= 12 and image_data[:4] == b"RIFF" and image_data[8:12] == b"WEBP":
+            image_format = "webp"
+        else:
+            # Fall back to extension-based detection
+            image_format = {
+                "png": "png",
+                "jpg": "jpeg",
+                "jpeg": "jpeg",
+                "gif": "gif",
+                "webp": "webp",
+            }[file_ext]
 
         return Image(data=image_data, format=image_format)
 

--- a/mcp_servers/filesystem/pyproject.toml
+++ b/mcp_servers/filesystem/pyproject.toml
@@ -93,3 +93,6 @@ ignore = [
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/mail/pyproject.toml
+++ b/mcp_servers/mail/pyproject.toml
@@ -84,3 +84,6 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/pdfs/pyproject.toml
+++ b/mcp_servers/pdfs/pyproject.toml
@@ -65,3 +65,6 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/presentations/pyproject.toml
+++ b/mcp_servers/presentations/pyproject.toml
@@ -71,3 +71,6 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"

--- a/mcp_servers/spreadsheets/pyproject.toml
+++ b/mcp_servers/spreadsheets/pyproject.toml
@@ -62,3 +62,6 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
+
+[tool.uv.constraint-dependencies]
+fakeredis = "<2.27"


### PR DESCRIPTION
## Summary

Three fixes discovered during delivery E2E testing:

- **Pin `fakeredis<2.27`** in all 9 MCP server `pyproject.toml` files — `pydocket` (transitive dep of `fastmcp`) imports `FakeConnection` which was renamed in fakeredis 2.27+ ([cunla/fakeredis-py#468](https://github.com/cunla/fakeredis-py/issues/468))
- **Fix `simple_task/mcp_config.json`** — use `uv` command (not `python`) and add `MCP_TRANSPORT=stdio` env var, consistent with the `hugging_face_task` config
- **Detect image format from magic bytes** in `read_image_file` — extension-based detection returns wrong MIME type when file content doesn't match extension, causing LLM API rejections

## Test plan

- [x] Verified fakeredis 2.26.x has `FakeConnection` and 2.27+ doesn't
- [x] Verified `simple_task` example runs E2E with the MCP config fix (scored 1.0 on gorilla task)
- [x] Verified image format detection works with mismatched extensions (JPEG in .png file)
- [x] Ran 22 worlds end-to-end with these fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)