### PR TITLE
fix: correct constraint-dependencies TOML format

### DIFF
--- a/mcp_servers/calendar/pyproject.toml
+++ b/mcp_servers/calendar/pyproject.toml
@@ -74,5 +74,5 @@ ignore = [
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/chat/pyproject.toml
+++ b/mcp_servers/chat/pyproject.toml
@@ -73,5 +73,5 @@ ignore = [
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/code/pyproject.toml
+++ b/mcp_servers/code/pyproject.toml
@@ -120,5 +120,5 @@ ignore = [
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/documents/pyproject.toml
+++ b/mcp_servers/documents/pyproject.toml
@@ -92,5 +92,5 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/filesystem/pyproject.toml
+++ b/mcp_servers/filesystem/pyproject.toml
@@ -94,5 +94,5 @@ ignore = [
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/mail/pyproject.toml
+++ b/mcp_servers/mail/pyproject.toml
@@ -85,5 +85,5 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/pdfs/pyproject.toml
+++ b/mcp_servers/pdfs/pyproject.toml
@@ -66,5 +66,5 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/presentations/pyproject.toml
+++ b/mcp_servers/presentations/pyproject.toml
@@ -72,5 +72,5 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]

--- a/mcp_servers/spreadsheets/pyproject.toml
+++ b/mcp_servers/spreadsheets/pyproject.toml
@@ -63,5 +63,5 @@ per-file-ignores = { "mcp_servers/**/tools/_meta_tools.py" = ["E501"] }
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = ["fakeredis<2.27"]


### PR DESCRIPTION
## Summary

Fixes the TOML format error introduced in #30. `constraint-dependencies` should be an array under `[tool.uv]`, not a separate TOML table.

**Before** (broken — `uv sync` fails with "invalid type: map, expected a sequence"):
```toml
[tool.uv.constraint-dependencies]
fakeredis = "<2.27"
```

**After** (correct):
```toml
[tool.uv]
constraint-dependencies = ["fakeredis<2.27"]
```

## Test plan
- [x] `uv sync` succeeds on all 9 MCP servers
- [x] Constraint recorded correctly in uv.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)