### PR TITLE
fix: use correct TOML syntax for uv constraint-dependencies

### DIFF
--- a/mcp_servers/filesystem/pyproject.toml
+++ b/mcp_servers/filesystem/pyproject.toml
@@ -94,5 +94,7 @@ ignore = [
 [tool.uv.sources]
 mcp-schema = { path = "packages/mcp_schema" }
 
-[tool.uv.constraint-dependencies]
-fakeredis = "<2.27"
+[tool.uv]
+constraint-dependencies = [
+    "fakeredis<2.27",
+]


### PR DESCRIPTION
## Summary
- `constraint-dependencies` in `mcp_servers/filesystem/pyproject.toml` was defined as a TOML table (`[tool.uv.constraint-dependencies]`) instead of a list
- This caused `uv sync` to fail with `invalid type: map, expected a sequence`, preventing the filesystem MCP server from starting in the environment container
- The `argus_agent` integration test was failing with a 300s timeout because the MCP server never initialized

## Testing
Ran it with the archipelago environment and confirmed it started up just fine.
```
archipelago-environment  | 2026-04-13 16:58:59.206 | INFO     | runner.gateway.router:set_apps:49 - Configured MCP gateway with 1 server(s): filesystem_server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)