### PR TITLE
fix(deps): pin litellm strictly to ==1.83.0

### DIFF
--- a/grading/pyproject.toml
+++ b/grading/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "asyncpg>=0.30.0",
     "duckdb>=1.0.0",
     "firecrawl-py>=1.0.0",
-    "litellm>=1.81.15,<2.0.0",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",

--- a/mcp_servers/calendar/pyproject.toml
+++ b/mcp_servers/calendar/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/calendar/smoke_test/pyproject.toml
+++ b/mcp_servers/calendar/smoke_test/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "fastmcp>=2.12.4",
     "testcontainers>=4.0.0",
     "tomli>=2.0.0",
-    "litellm>=1.50.0",
+    "litellm==1.83.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "loguru>=0.7.0",

--- a/mcp_servers/chat/pyproject.toml
+++ b/mcp_servers/chat/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/chat/smoke_test/pyproject.toml
+++ b/mcp_servers/chat/smoke_test/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "fastmcp>=2.12.4",
     "testcontainers>=4.0.0",
     "tomli>=2.0.0",
-    "litellm>=1.50.0",
+    "litellm==1.83.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "loguru>=0.7.0",

--- a/mcp_servers/code/pyproject.toml
+++ b/mcp_servers/code/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/code/smoke_test/pyproject.toml
+++ b/mcp_servers/code/smoke_test/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "fastmcp>=2.12.4",
     "testcontainers>=4.0.0",
     "tomli>=2.0.0",
-    "litellm>=1.50.0",
+    "litellm==1.83.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "loguru>=0.7.0",

--- a/mcp_servers/documents/pyproject.toml
+++ b/mcp_servers/documents/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/documents/smoke_test/pyproject.toml
+++ b/mcp_servers/documents/smoke_test/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "tomli>=2.0.0",
     
     # LLM providers (via LiteLLM)
-    "litellm>=1.50.0",
+    "litellm==1.83.0",
     
     # Agent runner dependencies
     "pydantic>=2.0.0",

--- a/mcp_servers/filesystem/pyproject.toml
+++ b/mcp_servers/filesystem/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/filesystem/smoke_test/pyproject.toml
+++ b/mcp_servers/filesystem/smoke_test/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "tomli>=2.0.0",
     
     # LLM providers (via LiteLLM)
-    "litellm>=1.50.0",
+    "litellm==1.83.0",
     
     # Agent runner dependencies
     "pydantic>=2.0.0",

--- a/mcp_servers/mail/pyproject.toml
+++ b/mcp_servers/mail/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/mail/smoke_test/pyproject.toml
+++ b/mcp_servers/mail/smoke_test/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "pytest>=8.0.0", "pytest-asyncio>=0.24.0", "httpx>=0.27.0", "fastmcp>=2.12.4",
-    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm>=1.50.0", "pydantic>=2.0.0",
+    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm==1.83.0", "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0", "loguru>=0.7.0",
 ]
 

--- a/mcp_servers/pdfs/pyproject.toml
+++ b/mcp_servers/pdfs/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/pdfs/smoke_test/pyproject.toml
+++ b/mcp_servers/pdfs/smoke_test/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "pytest>=8.0.0", "pytest-asyncio>=0.24.0", "httpx>=0.27.0", "fastmcp>=2.12.4",
-    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm>=1.50.0", "pydantic>=2.0.0",
+    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm==1.83.0", "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0", "loguru>=0.7.0",
 ]
 

--- a/mcp_servers/presentations/pyproject.toml
+++ b/mcp_servers/presentations/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/presentations/smoke_test/pyproject.toml
+++ b/mcp_servers/presentations/smoke_test/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "pytest>=8.0.0", "pytest-asyncio>=0.24.0", "httpx>=0.27.0", "fastmcp>=2.12.4",
-    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm>=1.50.0", "pydantic>=2.0.0",
+    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm==1.83.0", "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0", "loguru>=0.7.0",
 ]
 

--- a/mcp_servers/spreadsheets/pyproject.toml
+++ b/mcp_servers/spreadsheets/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "datadog-api-client>=2.44.0",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "litellm>=1.77.7",
+    "litellm==1.83.0",
     "loguru>=0.7.3",
     "mcp-schema",
     "pydantic-settings>=2.11.0",

--- a/mcp_servers/spreadsheets/smoke_test/pyproject.toml
+++ b/mcp_servers/spreadsheets/smoke_test/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "pytest>=8.0.0", "pytest-asyncio>=0.24.0", "httpx>=0.27.0", "fastmcp>=2.12.4",
-    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm>=1.50.0", "pydantic>=2.0.0",
+    "testcontainers>=4.0.0", "tomli>=2.0.0", "litellm==1.83.0", "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0", "loguru>=0.7.0",
 ]
 


### PR DESCRIPTION
Pins litellm to strict ==1.83.0 (was >= or unpinned). Audited-clean version.