### PR TITLE
fix: report stdout when lifecycle hook stderr is empty

### DIFF
--- a/environment/runner/data/populate/main.py
+++ b/environment/runner/data/populate/main.py
@@ -51,8 +51,20 @@ async def run_lifecycle_hook(hook: LifecycleHook) -> None:
     stdout, stderr = await proc.communicate()
 
     if proc.returncode != 0:
-        # Use errors='replace' to handle binary output gracefully
-        error_msg = stderr.decode(errors="replace") if stderr else "No error output"
+        # Use errors='replace' to handle binary output gracefully.
+        # Many hooks merge stderr into stdout (e.g. `exec 2>&1` or
+        # `exec > >(tee …) 2>&1`), so check both streams for diagnostics.
+        stderr_text = stderr.decode(errors="replace").strip() if stderr else ""
+        stdout_text = stdout.decode(errors="replace").strip() if stdout else ""
+
+        if stderr_text:
+            error_msg = stderr_text
+        elif stdout_text:
+            # stderr was empty/redirected — fall back to stdout
+            error_msg = stdout_text
+        else:
+            error_msg = "No error output on stdout or stderr"
+
         logger.error(
             f"Lifecycle hook '{hook.name}' failed with exit code {proc.returncode}: {error_msg}"
         )


### PR DESCRIPTION
## Summary
- Lifecycle hooks that merge stderr into stdout (e.g. chatwoot's `populate.sh` uses `exec > >(tee …) 2>&1`) produced an unhelpful **"No error output"** message on failure, because the runner only checked stderr
- Now falls back to stdout when stderr is empty, so actual error details (CSV import validation failures, FK resolution errors, etc.) are visible in logs and API responses

## Context
The chatwoot populate hook was failing with:
```
Lifecycle hook 'chatwoot' failed with exit code 1: No error output
```
The real errors were sitting in stdout the whole time, just never reported.

## Test plan
- [ ] Deploy to a sandbox and trigger a chatwoot populate with bad CSV data — verify the actual error message now appears instead of "No error output"
- [ ] Verify hooks that write to stderr directly still report correctly (stderr takes priority)
- [ ] Verify successful hooks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)