### PR TITLE
Reuse a single MCP session in loop agent

### DIFF
--- a/agents/runner/agents/loop_agent/main.py
+++ b/agents/runner/agents/loop_agent/main.py
@@ -75,12 +75,11 @@ class LoopAgent:
         self.status: AgentStatus = AgentStatus.PENDING
         self._usage_tracker: UsageTracker = UsageTracker()
 
-    async def _initialize_tools(self) -> None:
+    async def _initialize_tools(self, client: Any) -> None:
         """Load available tools from the MCP gateway."""
-        async with self.mcp_client as client:
-            tools: list[ChatCompletionToolParam] = await load_mcp_tools(
-                client.session, format="openai"
-            )  # pyright: ignore[reportAssignmentType]
+        tools: list[ChatCompletionToolParam] = await load_mcp_tools(
+            client.session, format="openai"
+        )  # pyright: ignore[reportAssignmentType]
 
         logger.bind(
             message_type="configure",
@@ -88,7 +87,7 @@ class LoopAgent:
         ).info(f"Loaded {len(tools)} MCP tools")
         self.tools = tools
 
-    async def step(self):
+    async def step(self, client: Any) -> None:
         """Execute a single step of the agent loop."""
         self.current_step += 1
 
@@ -151,99 +150,99 @@ class LoopAgent:
         self.messages.append(response_message)
 
         if tool_calls:
-            deferred_image_messages: list[LitellmInputMessage] = []
-            async with self.mcp_client as client:
-                for tool_call in tool_calls:
-                    name = tool_call.function.name
-
-                    tool_logger = logger.bind(
-                        ref=tool_call.id,
-                        name=name,
-                    )
-
-                    tool_logger.bind(
-                        message_type="tool_call", payload=tool_call.function.arguments
-                    ).info(f"Calling tool {name}")
-
-                    tool_result_logger = tool_logger.bind(message_type="tool_result")
-
-                    try:
-                        call_result = await asyncio.wait_for(
-                            call_openai_tool(client.session, tool_call),
-                            timeout=self.tool_call_timeout,
-                        )
-                    except TimeoutError:
-                        tool_result_logger.error(f"Tool call {name} timed out")
-                        self.messages.append(
-                            LitellmOutputMessage(
-                                role="tool",
-                                tool_call_id=tool_call.id,
-                                name=tool_call.function.name,
-                                content="Tool call timed out",
-                            )
-                        )
-                        continue
-                    except Exception as e:
-                        if is_fatal_mcp_error(e):
-                            tool_result_logger.error(
-                                f"Fatal MCP error, ending run: {repr(e)}"
-                            )
-                            self.messages.append(
-                                LitellmOutputMessage(
-                                    role="tool",
-                                    tool_call_id=tool_call.id,
-                                    name=tool_call.function.name,
-                                    content=f"Fatal error: {e}",
-                                )
-                            )
-                            raise
-                        tool_result_logger.error(
-                            f"Error calling tool {name}: {repr(e)}"
-                        )
-                        self.messages.append(
-                            LitellmOutputMessage(
-                                role="tool",
-                                tool_call_id=tool_call.id,
-                                name=tool_call.function.name,
-                                content=f"Error calling tool: {repr(e)}",
-                            )
-                        )
-                        continue
-
-                    if not call_result.content:
-                        tool_result_logger.error(
-                            f"Call result for {name} is not valid: {call_result.content}"
-                        )
-                        self.messages.append(
-                            LitellmOutputMessage(
-                                role="tool",
-                                tool_call_id=tool_call.id,
-                                name=tool_call.function.name,
-                                content=f"Call result is not valid, received {call_result.content}",
-                            )
-                        )
-                        continue
-
-                    messages = content_blocks_to_messages(
-                        call_result.content,
-                        tool_call.id,
-                        tool_call.function.name or "unknown",
-                        self.model,
-                        deferred_image_messages=deferred_image_messages,
-                    )
-
-                    tool_result_logger.bind(
-                        payload=[result.model_dump() for result in call_result.content],
-                    ).info(f"Tool {name} called successfully")
-
-                    self.messages.extend(messages)
-            self.messages.extend(deferred_image_messages)
+            await self._handle_tool_calls(client, tool_calls)
         else:
             # No tool calls = task complete
             self._finalized = True
             finalize_answer(
                 response_message.content if response_message.content else "No content"
             )
+
+    async def _handle_tool_calls(self, client: Any, tool_calls: list[Any]) -> None:
+        """Execute tool calls using the active MCP session."""
+        deferred_image_messages: list[LitellmInputMessage] = []
+
+        for tool_call in tool_calls:
+            name = tool_call.function.name
+
+            tool_logger = logger.bind(
+                ref=tool_call.id,
+                name=name,
+            )
+
+            tool_logger.bind(
+                message_type="tool_call", payload=tool_call.function.arguments
+            ).info(f"Calling tool {name}")
+
+            tool_result_logger = tool_logger.bind(message_type="tool_result")
+
+            try:
+                call_result = await asyncio.wait_for(
+                    call_openai_tool(client.session, tool_call),
+                    timeout=self.tool_call_timeout,
+                )
+            except TimeoutError:
+                tool_result_logger.error(f"Tool call {name} timed out")
+                self.messages.append(
+                    LitellmOutputMessage(
+                        role="tool",
+                        tool_call_id=tool_call.id,
+                        name=tool_call.function.name,
+                        content="Tool call timed out",
+                    )
+                )
+                continue
+            except Exception as e:
+                if is_fatal_mcp_error(e):
+                    tool_result_logger.error(f"Fatal MCP error, ending run: {repr(e)}")
+                    self.messages.append(
+                        LitellmOutputMessage(
+                            role="tool",
+                            tool_call_id=tool_call.id,
+                            name=tool_call.function.name,
+                            content=f"Fatal error: {e}",
+                        )
+                    )
+                    raise
+                tool_result_logger.error(f"Error calling tool {name}: {repr(e)}")
+                self.messages.append(
+                    LitellmOutputMessage(
+                        role="tool",
+                        tool_call_id=tool_call.id,
+                        name=tool_call.function.name,
+                        content=f"Error calling tool: {repr(e)}",
+                    )
+                )
+                continue
+
+            if not call_result.content:
+                tool_result_logger.error(
+                    f"Call result for {name} is not valid: {call_result.content}"
+                )
+                self.messages.append(
+                    LitellmOutputMessage(
+                        role="tool",
+                        tool_call_id=tool_call.id,
+                        name=tool_call.function.name,
+                        content=f"Call result is not valid, received {call_result.content}",
+                    )
+                )
+                continue
+
+            messages = content_blocks_to_messages(
+                call_result.content,
+                tool_call.id,
+                tool_call.function.name or "unknown",
+                self.model,
+                deferred_image_messages=deferred_image_messages,
+            )
+
+            tool_result_logger.bind(
+                payload=[result.model_dump() for result in call_result.content],
+            ).info(f"Tool {name} called successfully")
+
+            self.messages.extend(messages)
+        self.messages.extend(deferred_image_messages)
 
     def _build_output(self) -> AgentTrajectoryOutput:
         return AgentTrajectoryOutput(
@@ -257,40 +256,45 @@ class LoopAgent:
         """Run the agent loop until completion or timeout."""
         try:
             async with asyncio.timeout(self.timeout):
-                with logger.contextualize(model=self.model):
-                    logger.bind(message_type="configure").info(
-                        f"Starting agent loop with model {self.model}"
-                    )
-
-                    await self._initialize_tools()
-
-                    logger.bind(message_type="configure").info(
-                        "\n".join(
-                            f"{m['role'].capitalize()}: {m.get('content')}"
-                            for m in self.messages
+                async with self.mcp_client as client:
+                    with logger.contextualize(model=self.model):
+                        logger.bind(message_type="configure").info(
+                            f"Starting agent loop with model {self.model}"
                         )
-                    )
 
-                    logger.info("Starting agent loop")
-                    self.start_time = time.time()
-                    self.status = AgentStatus.RUNNING
+                        await self._initialize_tools(client)
 
-                    for i in range(self.max_steps):
-                        if self._finalized:
-                            logger.info(f"Agent loop was finalized after {i + 1} steps")
-                            break
-                        logger.bind(message_type="step").info(f"Starting step {i + 1}")
-                        await self.step()
-
-                    if not self._finalized:
-                        logger.error(
-                            f"Agent loop was not finalized after {self.max_steps} steps"
+                        logger.bind(message_type="configure").info(
+                            "\n".join(
+                                f"{m['role'].capitalize()}: {m.get('content')}"
+                                for m in self.messages
+                            )
                         )
-                        self.status = AgentStatus.FAILED
-                    else:
-                        self.status = AgentStatus.COMPLETED
 
-                    return self._build_output()
+                        logger.info("Starting agent loop")
+                        self.start_time = time.time()
+                        self.status = AgentStatus.RUNNING
+
+                        for i in range(self.max_steps):
+                            if self._finalized:
+                                logger.info(
+                                    f"Agent loop was finalized after {i + 1} steps"
+                                )
+                                break
+                            logger.bind(message_type="step").info(
+                                f"Starting step {i + 1}"
+                            )
+                            await self.step(client)
+
+                        if not self._finalized:
+                            logger.error(
+                                f"Agent loop was not finalized after {self.max_steps} steps"
+                            )
+                            self.status = AgentStatus.FAILED
+                        else:
+                            self.status = AgentStatus.COMPLETED
+
+                        return self._build_output()
 
         except TimeoutError:
             logger.error(f"Agent run timed out after {self.timeout} seconds")

--- a/agents/tests/test_loop_agent.py
+++ b/agents/tests/test_loop_agent.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from runner.agents.loop_agent.main import LoopAgent
+from runner.agents.models import AgentRunInput, AgentStatus
+
+
+class FakeMCPClient:
+    def __init__(self) -> None:
+        self.enter_count = 0
+        self.exit_count = 0
+        self.client = SimpleNamespace(session=object())
+
+    async def __aenter__(self) -> SimpleNamespace:
+        self.enter_count += 1
+        return self.client
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self.exit_count += 1
+
+
+@pytest.mark.asyncio
+async def test_loop_agent_reuses_single_mcp_session() -> None:
+    run_input = AgentRunInput(
+        trajectory_id="traj_test",
+        initial_messages=[{"role": "user", "content": "Solve the task"}],
+        mcp_gateway_url="http://example.com/mcp/",
+        mcp_gateway_auth_token=None,
+        orchestrator_model="openai/gpt-5",
+        orchestrator_extra_args=None,
+        agent_config_values={"max_steps": 3, "timeout": 5},
+    )
+    agent = LoopAgent(run_input)
+    fake_mcp_client = FakeMCPClient()
+    agent.mcp_client = fake_mcp_client
+
+    initialize_clients: list[object] = []
+    step_clients: list[object] = []
+
+    async def fake_initialize_tools(client: SimpleNamespace) -> None:
+        initialize_clients.append(client)
+
+    async def fake_step(client: SimpleNamespace) -> None:
+        step_clients.append(client)
+        if len(step_clients) == 2:
+            agent._finalized = True
+
+    agent._initialize_tools = fake_initialize_tools
+    agent.step = fake_step
+
+    output = await agent.run()
+
+    assert fake_mcp_client.enter_count == 1
+    assert fake_mcp_client.exit_count == 1
+    assert initialize_clients == [fake_mcp_client.client]
+    assert step_clients == [fake_mcp_client.client, fake_mcp_client.client]
+    assert output.status == AgentStatus.COMPLETED


### PR DESCRIPTION
## Summary
- keep a single MCP client session open for the entire  run instead of reconnecting on each step
- route tool loading and tool execution through that shared session
- add a regression test that verifies initialization and loop steps reuse the same MCP connection

## Testing
- ============================= test session starts ==============================
platform darwin -- Python 3.13.5, pytest-9.0.3, pluggy-1.5.0
rootdir: /Users/aknag/Desktop/archipelago
plugins: anyio-4.12.1
collected 0 items

============================ no tests ran in 0.02s =============================
- 
