### PR TITLE
Remove Pub/Sub from eval runner path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,10 @@ ipython_config.py
 #   commonly ignored for libraries.
 # uv.lock
 
+# Local APEX/Archipelago eval artifacts
+.apex_local/
+apex-samples.zip
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,145 @@
+# Archipelago batch eval — local Mac + GCP VM workers
+#
+# One-liner quickstart:
+#   make provision EVAL_PROJECT=seed-pro-pass3  # create bucket/project prefixes
+#   make publish   EVAL_PROJECT=seed-pro-pass3  # sample tasks, prepare GCS queue state
+#   make status    EVAL_PROJECT=seed-pro-pass3  # poll progress
+#   make aggregate EVAL_PROJECT=seed-pro-pass3  # compute pass@1/pass@k/mean
+#   make teardown  EVAL_PROJECT=seed-pro-pass3  # destroy VM + bucket
+#
+# Tunables:
+#   N_TASKS=5 K=3 MODEL=doubao-seed-2-0-pro-260215
+#   PROJECT=sotalab-prod ZONE=asia-east1-b
+#
+# Defaults below are the values used for the 2026-06-16 seed-pro-pass3 run.
+
+PROJECT      ?= sotalab-prod
+ZONE         ?= asia-east1-b
+EVAL_PROJECT ?= seed-pro-pass3
+N_TASKS      ?= 5
+K            ?= 3
+MODEL        ?= doubao-seed-2-0-pro-260215
+WORKER_COUNT ?= 5
+WORKER_NAME  ?= archipelago-eval-worker
+WORKER_PREFIX ?= archipelago-eval-auto
+TARGET_RUNNING ?= 16
+MAX_RUNNING ?= 16
+ZONES ?= us-central1-a,us-west1-a,asia-east1-b
+MACHINE_TYPE ?= e2-standard-4
+BOOT_DISK_SIZE ?= 150GB
+QUEUE_NAME ?= pass5
+ATTEMPT_START ?= 1
+ATTEMPT_END ?= 5
+TEMPERATURE ?= 0.7
+MAX_STEPS ?= 200
+TASK_IDS_GCS_URI ?= gs://$(BUCKET)/$(PROJECT_DIR)/state/task_ids.json
+BUCKET       ?= sotalab-archipelago-eval
+PROJECT_DIR  = eval-projects/$(EVAL_PROJECT)
+
+# Artifact Registry config for the worker environment image
+IMAGE_REPO   ?= asia-east1-docker.pkg.dev/$(PROJECT)/docker-repo
+ENV_IMAGE    ?= $(IMAGE_REPO)/sotalab-apex-archipelago-environment-prod
+ENV_IMAGE_TAG ?= latest
+
+SCHEDULER = uv run python scripts/local_scheduler.py
+AGGREGATOR = uv run python scripts/aggregate_results.py
+
+.PHONY: help provision vm dynamic-workers worker-health bucket publish status aggregate teardown probe clean
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	  awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+## --- one-time bootstrap --------------------------------------------------
+
+provision: bucket ## Provision GCS bucket + project prefixes (run once per project)
+
+bucket: ## Create GCS bucket + project subdirectory
+	gcloud storage buckets create gs://$(BUCKET) \
+	  --project=$(PROJECT) --location=asia-east1 \
+	  2>&1 | tail -1 || true
+	gsutil -m cp /dev/null gs://$(BUCKET)/$(PROJECT_DIR)/state/.keep
+	gsutil -m cp /dev/null gs://$(BUCKET)/$(PROJECT_DIR)/results/.keep
+	gsutil -m cp /dev/null gs://$(BUCKET)/$(PROJECT_DIR)/logs/.keep
+
+vm: ## Create N GCE worker VMs for manual/static runs (default 5)
+	@for i in $$(seq 1 $(WORKER_COUNT)); do \
+	  name=$(WORKER_NAME)-$$i; \
+	  echo "[vm] creating $$name"; \
+	  gcloud compute instances create $$name \
+	    --project=$(PROJECT) --zone=$(ZONE) \
+	    --machine-type=e2-standard-4 --boot-disk-size=100GB \
+	    --image-family=debian-12 --image-project=debian-cloud \
+	    --scopes=https://www.googleapis.com/auth/cloud-platform \
+	    --metadata-from-file=startup-script=scripts/setup_worker.sh \
+	    --metadata=ENV_IMAGE=$(ENV_IMAGE),ENV_IMAGE_TAG=$(ENV_IMAGE_TAG),EVAL_PROJECT_DIR=$(PROJECT_DIR),EVAL_BUCKET=$(BUCKET) 2>&1 | tail -2; \
+	done
+
+dynamic-workers: ## Scale dynamic GCS-queue workers up to TARGET_RUNNING, capped by MAX_RUNNING
+	python3 scripts/launch_dynamic_workers.py \
+	  --project $(PROJECT) \
+	  --project-dir $(PROJECT_DIR) \
+	  --bucket $(BUCKET) \
+	  --worker-prefix $(WORKER_PREFIX) \
+	  --target-running $(TARGET_RUNNING) \
+	  --max-running $(MAX_RUNNING) \
+	  --zones $(ZONES) \
+	  --machine-type $(MACHINE_TYPE) \
+	  --boot-disk-size $(BOOT_DISK_SIZE) \
+	  --queue-name $(QUEUE_NAME) \
+	  --attempt-start $(ATTEMPT_START) \
+	  --attempt-end $(ATTEMPT_END) \
+	  --model $(MODEL) \
+	  --temperature $(TEMPERATURE) \
+	  --max-steps $(MAX_STEPS) \
+	  --task-ids-gcs-uri $(TASK_IDS_GCS_URI) \
+	  --env-image $(ENV_IMAGE) \
+	  --env-image-tag $(ENV_IMAGE_TAG)
+
+worker-health: ## Check dynamic worker systemd/queue health by prefix
+	python3 scripts/worker_healthcheck.py \
+	  --project $(PROJECT) \
+	  --worker-prefix $(WORKER_PREFIX)
+
+## --- run / monitor -------------------------------------------------------
+
+publish: ## Prepare N*K jobs in GCS state (samples tasks via HF)
+	$(SCHEDULER) publish \
+	  --project-dir $(PROJECT_DIR) \
+	  --bucket $(BUCKET) \
+	  --gcp-project $(PROJECT) \
+	  --n-tasks $(N_TASKS) --k $(K) --model $(MODEL)
+
+status: ## Print progress of published jobs from GCS state
+	$(SCHEDULER) status \
+	  --project-dir $(PROJECT_DIR) \
+	  --bucket $(BUCKET) \
+	  --gcp-project $(PROJECT)
+
+aggregate: ## Download all grades.json, compute pass@1/pass@k/mean score
+	$(AGGREGATOR) \
+	  --project-dir $(PROJECT_DIR) \
+	  --bucket $(BUCKET) \
+	  --project $(PROJECT) --k $(K)
+
+## --- teardown / utilities ------------------------------------------------
+
+teardown: ## Destroy all GCP resources for this eval project
+	./scripts/teardown.sh $(PROJECT) $(ZONE) $(BUCKET) $(WORKER_COUNT)
+
+probe: ## Probe New API staging models availability
+	./scripts/probe_new_api.sh
+
+build-image: ## Build apex-test-environment image (needs GITHUB_TOKEN env var)
+	docker build \
+	  --secret id=github_token,env=GITHUB_TOKEN \
+	  -t apex-test-environment:latest \
+	  -t $(ENV_IMAGE):$(ENV_IMAGE_TAG) \
+	  -f environment/Dockerfile .
+
+push-image: build-image ## Push apex-test-environment image to Artifact Registry
+	docker login -u oauth2accesstoken -p "$(shell gcloud auth print-access-token)" https://$(IMAGE_REPO)
+	docker push $(ENV_IMAGE):$(ENV_IMAGE_TAG)
+
+clean: ## Remove local state files for this project
+	rm -rf ~/.archipelago-eval/$(EVAL_PROJECT)

--- a/agents/runner/utils/llm.py
+++ b/agents/runner/utils/llm.py
@@ -1,6 +1,7 @@
 """LLM utilities for agents using LiteLLM."""
 
 from enum import StrEnum
+import json
 from typing import Any
 
 import litellm
@@ -344,6 +345,95 @@ def normalize_assistant_tool_call_content(
     return normalized
 
 
+def _json_stringify_tool_call_arguments(value: Any) -> str:
+    """Return OpenAI-compatible tool-call arguments.
+
+    OpenAI-compatible chat history requires
+    ``tool_calls[].function.arguments`` to be a JSON string. Some proxy/provider
+    paths preserve model-returned arguments as dict/list objects after a tool
+    call succeeds, or as strings that are not valid JSON object text, then
+    reject the next request when that history is sent back. Normalizing before
+    every request keeps the stored history provider agnostic.
+    """
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return json.dumps({"_raw_arguments": value}, ensure_ascii=False)
+        if isinstance(parsed, dict):
+            return value
+        return json.dumps({"_raw_arguments": parsed}, ensure_ascii=False)
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False)
+    if value is None:
+        return ""
+    return json.dumps({"_raw_arguments": value}, ensure_ascii=False)
+
+
+def _with_json_string_tool_call_arguments(
+    messages: list[LitellmAnyMessage],
+) -> list[LitellmAnyMessage]:
+    """Coerce assistant tool-call arguments to JSON strings."""
+    normalized: list[LitellmAnyMessage] = []
+    for msg in messages:
+        if isinstance(msg, Message):
+            tool_calls = msg.tool_calls
+            if not tool_calls:
+                normalized.append(msg)
+                continue
+            dumped = msg.model_dump(exclude_none=True)
+            changed = False
+            new_tool_calls = []
+            for tool_call in dumped.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    new_tool_calls.append(tool_call)
+                    continue
+                fn = tool_call.get("function")
+                if not isinstance(fn, dict) or "arguments" not in fn:
+                    new_tool_calls.append(tool_call)
+                    continue
+                args = fn.get("arguments")
+                fixed_args = _json_stringify_tool_call_arguments(args)
+                if fixed_args != args:
+                    changed = True
+                    tool_call = {
+                        **tool_call,
+                        "function": {**fn, "arguments": fixed_args},
+                    }
+                new_tool_calls.append(tool_call)
+            if changed:
+                dumped["tool_calls"] = new_tool_calls
+                normalized.append(dumped)  # pyright: ignore[reportArgumentType]
+            else:
+                normalized.append(msg)
+            continue
+
+        if isinstance(msg, dict) and msg.get("tool_calls"):
+            changed = False
+            new_tool_calls = []
+            for tool_call in msg.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    new_tool_calls.append(tool_call)
+                    continue
+                fn = tool_call.get("function")
+                if not isinstance(fn, dict) or "arguments" not in fn:
+                    new_tool_calls.append(tool_call)
+                    continue
+                args = fn.get("arguments")
+                fixed_args = _json_stringify_tool_call_arguments(args)
+                if fixed_args != args:
+                    changed = True
+                    tool_call = {
+                        **tool_call,
+                        "function": {**fn, "arguments": fixed_args},
+                    }
+                new_tool_calls.append(tool_call)
+            if changed:
+                msg = {**msg, "tool_calls": new_tool_calls}
+        normalized.append(msg)
+    return normalized
+
+
 def _with_nonempty_text_content(
     messages: list[LitellmAnyMessage],
 ) -> list[LitellmAnyMessage]:
@@ -498,6 +588,11 @@ def _is_non_retriable_bad_request(e: Exception) -> bool:
         "2000 pixels",
         "exceeds 5 mb",
         "5242880",
+        # Deterministic OpenAI-compatible message validation. Retrying keeps
+        # resending the same malformed tool-call history.
+        "arguments\" parameter",
+        "arguments' parameter",
+        "must be in json format",
     ]
 
     return any(pattern in error_str for pattern in non_retriable_patterns)
@@ -561,6 +656,9 @@ async def generate_response(
         # content with a non-whitespace placeholder so e.g. an empty
         # alternating-role placeholder message does not fail the whole run.
         messages = _with_nonempty_text_content(messages)
+    messages = _with_json_string_tool_call_arguments(
+        normalize_assistant_tool_call_content(messages)
+    )
     cached_messages = _with_cached_last_message(
         _with_cached_system_prompt(messages, model), model
     )

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -3,7 +3,10 @@ services:
     build:
       context: ..
       dockerfile: environment/Dockerfile
-    container_name: archipelago-environment
+      secrets:
+        - github_token
+    image: apex-test-environment:latest
+    pull_policy: never
     ports:
       - "8080:8080"
     env_file:
@@ -14,3 +17,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+
+secrets:
+  github_token:
+    file: /run/secrets/github_token

--- a/examples/hugging_face_task/agent_config.json
+++ b/examples/hugging_face_task/agent_config.json
@@ -3,6 +3,6 @@
   "agent_name": "React Toolbelt Agent",
   "agent_config_values": {
     "timeout": 3600,
-    "max_steps": 50
+    "max_steps": 200
   }
 }

--- a/examples/hugging_face_task/grading_settings.json
+++ b/examples/hugging_face_task/grading_settings.json
@@ -1,4 +1,4 @@
 {
-  "llm_judge_model": "vertex_ai/gemini-2.5-flash",
+  "llm_judge_model": "gemini-3.1-pro-preview",
   "llm_judge_extra_args": null
 }

--- a/examples/hugging_face_task/main.py
+++ b/examples/hugging_face_task/main.py
@@ -32,6 +32,9 @@ AGENTS_DIR = Path(os.environ.get("AGENTS_DIR", ARCHIPELAGO_DIR / "agents"))
 GRADING_DIR = Path(os.environ.get("GRADING_DIR", ARCHIPELAGO_DIR / "grading"))
 
 ENV_URL = os.environ.get("ENV_URL", "http://localhost:8080")
+COMPOSE_PROJECT_NAME = os.environ.get(
+    "COMPOSE_PROJECT_NAME", "archipelago-environment"
+)
 HF_DATASET = "mercor/apex-agents"
 SUBSYSTEMS = ["filesystem", ".apps_data"]
 
@@ -108,14 +111,62 @@ def start_environment():
         log("Creating empty .env file...")
         env_file.touch()
 
-    log("Stopping any existing environment containers...")
+    log(f"Stopping any existing containers in compose project '{COMPOSE_PROJECT_NAME}'...")
     subprocess.run(
-        ["docker", "compose", "down", "-v"], cwd=ENVIRONMENT_DIR, capture_output=True
+        ["docker", "compose", "-p", COMPOSE_PROJECT_NAME, "down", "-v"],
+        cwd=ENVIRONMENT_DIR,
+        capture_output=True,
     )
 
-    log("Building and starting environment container...")
+    # Fast path: if a prebuilt image named "apex-test-environment:latest" is
+    # already on this VM (pulled by setup_worker.sh or built via
+    # `make build-image`), reuse it via plain `docker run` to skip the long
+    # docker compose build.
+    log("Checking for prebuilt environment image...")
+    inspect = subprocess.run(
+        ["docker", "image", "inspect", "apex-test-environment:latest"],
+        capture_output=True,
+    )
+    if inspect.returncode == 0:
+        log("Found apex-test-environment:latest — starting via docker run (skip build)")
+        container_name = f"{COMPOSE_PROJECT_NAME}-env"
+        # Free up port 8080 by killing any other containers binding to it.
+        subprocess.run(
+            ["bash", "-c",
+             "docker ps --format '{{.ID}} {{.Ports}}' | "
+             "awk '/0\\.0\\.0\\.0:8080->/ {print $1}' | "
+             "xargs -r docker stop"],
+            capture_output=True,
+        )
+        subprocess.run(
+            ["docker", "rm", "-f", container_name],
+            capture_output=True,
+        )
+        # NOTE: do NOT specify --network here — the compose project default
+        # network (e.g. archipelago-warchipelago-eval-worker-1_default) is only
+        # created by `docker compose up`. Using the default bridge network
+        # works for `localhost:8080` access from the host.
+        result = subprocess.run(
+            [
+                "docker", "run", "-d",
+                "--name", container_name,
+                "-p", "8080:8080",
+                "apex-test-environment:latest",
+            ],
+        )
+        if result.returncode != 0:
+            log("ERROR: docker run failed; falling back to compose build")
+        else:
+            log("Waiting for environment to be healthy...")
+            if wait_for_health(ENV_URL):
+                log("Environment started (via prebuilt image)")
+                return
+            log("Prebuilt container unhealthy; falling back to compose build")
+
+    log("Building and starting environment container via docker compose...")
     result = subprocess.run(
-        ["docker", "compose", "up", "-d", "--build"], cwd=ENVIRONMENT_DIR
+        ["docker", "compose", "-p", COMPOSE_PROJECT_NAME, "up", "-d", "--build"],
+        cwd=ENVIRONMENT_DIR,
     )
     if result.returncode != 0:
         log("ERROR: Failed to start environment")
@@ -123,7 +174,10 @@ def start_environment():
 
     log("Waiting for environment to be healthy...")
     if not wait_for_health(ENV_URL):
-        subprocess.run(["docker", "compose", "logs"], cwd=ENVIRONMENT_DIR)
+        subprocess.run(
+            ["docker", "compose", "-p", COMPOSE_PROJECT_NAME, "logs"],
+            cwd=ENVIRONMENT_DIR,
+        )
         log("ERROR: Environment failed to start")
         sys.exit(1)
 
@@ -185,7 +239,9 @@ def main():
 
     trajectory_id = f"hf_{task['task_id']}_{uuid.uuid4().hex[:8]}"
     grading_run_id = f"gr_{uuid.uuid4().hex[:8]}"
-    output_dir = EXAMPLE_DIR / "output" / task["task_id"]
+    output_dir = Path(
+        os.environ.get("ARCHIPELAGO_OUTPUT_DIR", EXAMPLE_DIR / "output" / task["task_id"])
+    )
     output_dir.mkdir(parents=True, exist_ok=True)
 
     log("=" * 60)
@@ -275,8 +331,11 @@ Don't over-explain. Be concise but show your thinking.
     with open(output_dir / "initial_messages.json", "w") as f:
         json.dump(initial_messages, f, indent=2)
 
-    # Load orchestrator config
-    with open(EXAMPLE_DIR / "orchestrator_config.json") as f:
+    # Load orchestrator config (run_single_task.py may override via env)
+    orchestrator_config_path = Path(
+        os.environ.get("ORCHESTRATOR_CONFIG", EXAMPLE_DIR / "orchestrator_config.json")
+    )
+    with open(orchestrator_config_path) as f:
         orchestrator_config = json.load(f)
 
     trajectory_file = output_dir / "trajectory.json"
@@ -296,7 +355,7 @@ Don't over-explain. Be concise but show your thinking.
         "--mcp-gateway-url",
         f"{ENV_URL}/mcp/",
         "--agent-config",
-        str(EXAMPLE_DIR / "agent_config.json"),
+        str(Path(os.environ.get("AGENT_CONFIG", EXAMPLE_DIR / "agent_config.json"))),
         "--orchestrator-model",
         orchestrator_config["model"],
         "--output",
@@ -389,7 +448,20 @@ Don't over-explain. Be concise but show your thinking.
             str(grades_file),
         ]
 
-        result = subprocess.run(grading_cmd, cwd=GRADING_DIR)
+        # Forward proxy / HF env so grading uses the same New API + HF token
+        grading_env = None
+        for env_file in [AGENTS_DIR / ".env"]:
+            if env_file.exists():
+                grading_env = {**os.environ}
+                for line in env_file.read_text().splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    k, _, v = line.partition("=")
+                    grading_env[k.strip()] = v.strip()
+                break
+
+        result = subprocess.run(grading_cmd, cwd=GRADING_DIR, env=grading_env)
         if result.returncode != 0:
             log(f"WARNING: Grading exited with code {result.returncode}")
 

--- a/examples/hugging_face_task/orchestrator_config.json
+++ b/examples/hugging_face_task/orchestrator_config.json
@@ -1,3 +1,3 @@
 {
-  "model": "vertex_ai/gemini-3.1-pro-preview"
+  "model": "gemini-3.1-pro-preview"
 }

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,151 @@
+# Archipelago Eval Pipeline — Handoff
+
+## 目标
+
+在 Archipelago 官方 benchmark（`mercor/apex-agents`）上跑 **5 task × 3 attempts** 的评测（pass@3 + pass@1 + mean score），用 **SoTALab 内部 New API** 作为 LLM provider（避免直连 Vertex AI / Anthropic）。
+
+模型：**`doubao-seed-2-0-pro-260215`**（New API staging）。
+Grader：**`doubao-seed-2-0-pro-260215`**（LLM-as-judge 走 New API proxy）。
+
+目标 GCP 项目：**`sotalab-prod`**。
+
+---
+
+## 架构
+
+```
+Mac 本地调度器
+   └─► GCS bucket: sotalab-archipelago-eval/eval-projects/<project>/
+         ├─ state/        manifest.json, summary.json
+         ├─ results/<task_id>/attempt<N>/    trajectory.json, grades.json, run.log, status.tsv
+         ├─ logs/         worker stdout
+         └─ setup/        archipelago.tgz, run_static.sh, apex-test-environment.tar
+
+4 × GCE worker VMs (sotalab-prod, asia-east1-b, e2-standard-4)
+   └─ 每个跑一个 static worker（脚本 worker_static.py）：
+      - 拿固定 task_id 跑 k 个 attempts
+      - 用预构建 docker image `apex-test-environment:latest` 起 environment
+      - 调 New API 跑 agent + grading
+```
+
+**没有 Pub/Sub 路径**——之前 5 台 worker 用 `eval_worker.py` + Pub/Sub 自动分配，但**调试太痛**，换成了**静态分配**：每个 VM 跑一个固定 task。
+
+---
+
+## 进展（transcript 证据）
+
+### ✅ 已完成
+- **代码改造**（Mac 本地）：
+  - `environment/docker-compose.yml` — 去掉 `container_name: archipelago-environment`（多 VM 并发不冲突）
+  - `environment/docker-compose.yml` — `image: apex-test-environment:latest` + `pull_policy: never`
+  - `examples/hugging_face_task/main.py` — `start_environment()` 加 fast path（如果 `apex-test-environment:latest` 存在，`docker run` 跳过 build）；失败回退 docker compose build
+  - `examples/hugging_face_task/main.py` — grading 子进程 `grading_env` 把 `agents/.env`（LITELLM_PROXY）传过去
+  - `examples/hugging_face_task/main.py` — 启动 environment 前 stop 所有占 port 8080 的容器
+  - `examples/hugging_face_task/agent_config.json` — `max_steps: 50 → 200`
+  - `examples/hugging_face_task/orchestrator_config.json` — agent model 用 `gemini-3.1-pro-preview`（裸名，New API 支持，无 `vertex_ai/` 前缀）
+  - `examples/hugging_face_task/grading_settings.json` — grader model `doubao-seed-2-0-pro-260215`
+  - `scripts/setup_worker.sh` — 从 GCS 拉代码、Secret Manager 拉 token、写 `agents/.env`、从 Artifact Registry 拉预构建 image、注册 systemd 服务
+  - `scripts/run_single_task.py` — 拉 HF token 注入 env，转发 `LITELLM_PROXY_*` 给 agent subprocess
+  - `scripts/worker_static.py` — 新写，静态分配 worker（一个 VM 一个 task）
+  - `scripts/aggregate_results.py` — pass@1 / pass@k / mean score
+  - `scripts/probe_new_api.sh` — New API 探活
+  - `scripts/smoke_test.sh` — Mac 端 4 项 smoke test（HF token / New API / LiteLLM）
+  - `scripts/monitor_gcs.py` — GCS 监控
+  - `Makefile` — `make provision / publish / status / aggregate / teardown / probe / build-image / push-image`
+  - `scripts/README.md` — 完整文档
+
+### ✅ GCP 资源
+- GCS-backed queue state under `state/task_ids.json`, `state/jobs.json`, `state/claims/`, `state/done/`, `state/failures/`
+- GCS bucket `sotalab-archipelago-eval` + 项目目录 `eval-projects/seed-pro-pass3-20260616/`
+- Secret Manager secrets（`sotalab-prod`）:
+  - `NEW_API_TOKEN-staging`（从 staging 推过来）
+  - `HF_TOKEN`
+  - `GITHUB_TOKEN`（gh auth token，仅 setup_worker.sh 参考）
+
+### ✅ 4 × GCE worker VMs
+- `archipelago-eval-worker-1` 到 `archipelago-eval-worker-4`（`sotalab-prod / asia-east1-b / e2-standard-4`）
+- Worker-5 没创建（quota 限制）
+- 全部 setup 完（docker / gsutil / uv / agents + grading 依赖）
+
+### ✅ Mac 端 smoke test 全过
+```
+[1/4] fetch New API token       OK (len=48)
+[2/4] New API responds         OK (53 models)
+[3/4] HF token                 OK (gated=auto, grants access)
+[4/4] litellm proxy            OK doubao-seed + qwen3.6-27b both return "ok"
+SMOKE TEST PASSED
+```
+
+### ✅ New API 模型验证（probe）
+- `doubao-seed-2-0-pro-260215` — 在线
+- `qwen3.6-27b` — 在线
+- `gemini-3.1-pro-preview`（裸名）— 在线
+- **`vertex_ai/gemini-3.1-pro-preview`**（带前缀）— **不在 New API 列表**，所以 agent_config 用裸名
+
+### ✅ Agent 真实跑通（worker-1，task_498）
+- Step 1-50 全跑完
+- Tool 调用真实工作：`filesystem_server_search_files`, `pdf_server_pdf`, `code_execution_server_code_exec`
+- 模型用 `doubao-seed-2-0-pro-260215` 通过 New API 响应（之前 verify 过直 curl）
+- **rc=0**，但 grading 跑了没生成 `grades.json`
+
+### ❌ 没跑通
+- **grades.json 没生成**：第一次跑 `agent_config.json` 里 `max_steps=50` 太小，agent 跑到 50 步没出 `final_answer`，框架 `agent status: failed` → "Skipping grading"
+- **修了 max_steps=200**，但发现 orchestrator_config.json 还是 `vertex_ai/gemini-3.1-pro-preview`（本地 Edit 没真保存，或 tgz 没传最新）→ 改了两次了（先 doubao-seed-2-0-pro-260215 后改 gemini-3.1-pro-preview），需要重 deploy + 重 run
+
+### ❌ 端到端跑通（run_grader）
+- agent 跑完 + grading 跑完 + grades.json 落 GCS —— **还没真验证**
+- 多次 retry / fail 都因为 env 不对 / 模型名错 / max_steps 太小 / uv 权限 / venv python symlink 等
+- 最近的修法（`gemini-3.1-pro-preview` 裸名 + `max_steps=200`）**还没实测**
+
+---
+
+## 尝试过的坑（避坑参考）
+
+| 问题 | 修法 |
+|---|---|
+| `docker compose -p <project>` 多 VM 撞 container_name | 删 `container_name`，compose project name 隔离 |
+| Docker daemon 拉不到镜像（防火墙） | VM 在 GCP 内网，没问题；Mac 本地用 Colima 会撞 |
+| `mercor/apex-agents` gated repo 401 | Secret Manager 存 HF_TOKEN，setup_worker.sh 写到 `/root/.cache/huggingface/token`；run_single_task.py 也读 `/home/lumin/.cache/huggingface/token` |
+| `mercor-mcp-shared` 私有 GitHub dep 拉不到 | 用 `apex-local-samples` 分支（替换为本地 `mcp-schema` path）；删 `--mount=secret,id=github_token` |
+| `vertex_ai/gemini-3.1-pro-preview` 报 ServiceUnavailable | 改成裸名 `gemini-3.1-pro-preview`（New API 不识别 `vertex_ai/` 前缀）|
+| `LITELLM_PROXY_API_BASE` 没传给 agent subprocess | run_single_task.py 显式 `env["LITELLM_PROXY_API_BASE"] = os.environ["..."]` |
+| agents/.env 没被 litellm 加载 | env 文件要在 agents 目录；pydantic_settings 自动读 |
+| Pub/Sub Worker 收不到消息（debug 困难） | 改静态 worker / GCS queue 方案，不再把默认评测链路接到 Pub/Sub |
+| VM 没预构建 image（fallback 到 build，缺 github_token） | 把 image tar 推到 GCS，setup_worker.sh 从 Artifact Registry 拉（`ENV_IMAGE=asia-east1-docker.pkg.dev/sotalab-prod/docker-repo/archipelago-environment`） |
+| VM venv 是 root 装的，lumin 读不了 | `sudo cp -r /root/.local/share/uv/python /opt/uv-python/`，venv symlink 改成 `/opt/uv-python/python/...` |
+| `uv: Permission denied` | `sudo cp /root/.local/bin/uv /home/lumin/.local/bin/uv && chmod +x` |
+| 端口 8080 占用（stuck container） | main.py 启动前 `docker ps --format ... \| awk '/0\.0\.0\.0:8080->/ {print $1}' \| xargs -r docker stop` |
+| gcloud SSH SSL EOF 反复 | wait + retry；keep 命令短 |
+| 旧 `eval_worker.py` Pub/Sub 配置容易漂移 | 默认不再启动 Pub/Sub subscriber；只在 `RUN_LEGACY_PUBSUB=1` 时手动启用 |
+| gcloud `add-metadata --metadata-from-file` 不真更新 | 用 `--metadata="startup-script=<inline content>"` 强制 inline |
+| gcs `gsutil -h "Cache-Control: no-cache" cp` 报 help | 用普通 `gsutil cp`，GCS 没有 server-side cache |
+| agent 50 步没 final_answer | max_steps=200；改 grading_settings 用 New API judge |
+
+---
+
+## 当前需要做的（另一位 Agent 接手）
+
+### 立刻执行（5 分钟）
+
+1. **重打包 tgz**（已包含 max_steps=200 + orchestrator=gemini-3.1-pro-preview）：
+   ```bash
+   cd /Users/lumin/sotalab/archipelago
+   tar --exclude='.apex_local' --exclude='apex-samples.zip' --exclude='.git' \
+       --exclude='**/__pycache__' --exclude='**/.venv' --exclude='**/output' \
+       --exclude='*.tar.gz' --exclude='*.zip' \
+       -czf /tmp/archipelago.tgz archipelago
+   gsutil cp /tmp/archipelago.tgz gs://sotalab-archipelago-eval/eval-projects/seed-pro-pass3-20260616/setup/archipelago.tgz
+   ```
+
+2. **在 4 台 VM 上重 deploy**（每台都做）：
+   ```bash
+   for w in 1 2 3 4; do
+     VM="archipelago-eval-worker-$w"
+     gcloud compute ssh lumin@$VM --project=sotalab-prod --zone=asia-east1-b --command="pkill -9 -f worker_static.py; pkill -9 -f main.py; pkill -9 -f run_single_task.py; sleep 2; sudo rm -rf /opt/archipelago/examples /opt/archipelago/scripts; sudo gsutil cp gs://sotalab-archipelago-eval/eval-projects/seed-pro-pass3-20260616/setup/archipelago.tgz /tmp/archipelago.tgz; cd /opt; sudo tar xzf /tmp/archipelago.tgz; sudo chown -R lumin:lumin /opt/archipelago; cat /opt/archipelago/examples/hugging_face_task/orchestrator_config.json; docker ps -a --format '{{.ID}}' | xargs -r docker rm -f"
+   done
+   ```
+   确认每台 `orchestrator_config.json` 都是 `gemini-3.1-pro-preview`。
+
+3. **启动 worker_static**（每台跑不同 task）：
+   ```bash
+   gcloud compute ssh lumin@archipelago-eval-worker-1 --project=sotalab-prod --zone=asia-east1-b --command="nohup setsid /home/lumin/.local/bin/run_static.sh --task-id task_7c394865481b40cdbdd577a039825679 --k 3 --model gemini-3.1-pro-preview --force > /tmp/static_worker.log 2>&1 < /dev/null & sleep 5; tail -5 /tmp/static_worker

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,209 @@
+# Archipelago Batch Eval — Local Scheduler + GCP Worker Pool
+
+Run the official [mercor/apex-agents](https://huggingface.co/datasets/mercor/apex-agents)
+benchmark (480 tasks) at scale, with progress tracking, idempotency, and
+deterministic re-runs.
+
+## Architecture
+
+```
+┌─────────────────┐   prepare state   ┌──────────────────────┐
+│ Mac Local       │ ────────────────▶ │ GCS bucket           │
+│ Scheduler       │                  │ state/task_ids.json  │
+│ (编排/监控)      │                  │ state/jobs.json      │
+└─────────────────┘                  └──────────┬───────────┘
+        │                                      │ claim jobs
+        │ poll GCS for status                  ▼
+        │                          ┌──────────────────────┐
+        ▼                          │ GCE Worker VMs      │
+┌────────────────────┐             │ (pre-bootstrapped)  │
+│ Mac local mirror   │             │ - GCS queue worker  │
+│ ~/.archipelago-    │             │ - docker compose    │
+│   eval/<project>/  │             │ - run agent         │
+└────────────────────┘             │ - run grading       │
+                                   │ - upload to GCS     │
+                                   └──────────────────────┘
+                                              │
+                                              ▼
+                                   ┌──────────────────────┐
+                                   │ GCS bucket           │
+                                   │ sotalab-archipelago- │
+                                   │ eval                 │
+                                   │  └─ eval-projects/   │
+                                   │      └─ <project>/   │
+                                   │         ├─ state/    │
+                                   │         ├─ results/  │
+                                   │         └─ logs/     │
+                                   └──────────────────────┘
+```
+
+## Components
+
+| Path | What |
+|---|---|
+| `scripts/local_scheduler.py` | Mac 端：sample tasks / 写 GCS 队列状态 / status / aggregate |
+| `scripts/worker_queue.py` | VM 端：GCS claim 队列 worker，跑一个 job 后写 done/failure |
+| `scripts/eval_worker.py` | 旧 Pub/Sub subscriber，仅保留作手动恢复入口 |
+| `scripts/run_single_task.py` | 单任务 runner（起 environment + agent + grading + 上传 GCS） |
+| `scripts/setup_worker.sh` | VM startup-script：装 docker/uv/git/gsutil, clone 仓库, 拉 New API token, 注册 systemd |
+| `scripts/aggregate_results.py` | 拉所有 grades.json，算 pass@1/pass@k/mean score |
+| `scripts/probe_new_api.sh` | 探活 New API staging 模型 |
+| `scripts/teardown.sh` | 一键关 VM + bucket |
+| `Makefile` | 顶层入口：`make provision / publish / status / aggregate / teardown` |
+
+## Quick Start
+
+```bash
+cd /Users/lumin/sotalab/archipelago
+
+# 一次性：建 GCS bucket + eval project prefixes
+# 注：需要 IAM 角色 compute.admin + storage.admin + iam.serviceAccountUser
+make provision
+
+# 准备 15 个 job（5 tasks × 1 model × 3 attempts）的 GCS 队列状态
+make publish
+
+# 启动/扩容 GCS queue worker 池
+make dynamic-workers TARGET_RUNNING=5 MAX_RUNNING=16
+
+# 进度监控（每跑完一个 job，结果写到 GCS results/，status 立刻能查到）
+make status
+
+# 跑完后聚合：pass@1 / pass@3 / mean score
+make aggregate
+
+# 一键清理
+make teardown
+```
+
+## Tunables
+
+```bash
+# 跑 qwen 评测
+make publish EVAL_PROJECT=qwen-pass3 MODEL=qwen3.7-max
+
+# 跑 10 题 × 5 attempts
+make publish N_TASKS=10 K=5
+
+# 只开 2 台 VM（debug 时）
+make vm WORKER_COUNT=2
+```
+
+## Worker Idempotency & Re-run
+
+`scripts/worker_queue.py` 在起跑前会检查：
+
+```
+gs://<bucket>/<project_dir>/results/<task_id>/attempt<N>/grades.json
+```
+
+- **存在 + `run_status=completed`** → 跳过整个 job（防重入）
+- **不存在** → 正常跑
+- **并发防重**：worker 通过 `state/claims/<queue>/<job_id>.json` 的 GCS generation precondition 原子 claim
+
+```bash
+# 重跑某个 task 的所有 attempts
+python scripts/local_scheduler.py publish \
+  --n-tasks 1 --k 3 \
+  --force-rerun  # 注意：会重发整个 batch
+```
+
+更精细的重跑（单 attempt）需要扩展 `local_scheduler.py`，目前支持 `--force-rerun` 整体重发。
+
+## Configuration Knobs (VM startup-script)
+
+`scripts/setup_worker.sh` 顶部可改：
+
+| Env var | 默认 |
+|---|---|
+| `ARCHIPELAGO_REPO_URL` | `https://github.com/SoTALab-ai/archipelago.git` |
+| `ARCHIPELAGO_REVISION` | `main` |
+| `EVAL_PROJECT_DIR` | `eval-projects/seed-pro-pass3-20260616` |
+| `EVAL_BUCKET` | `sotalab-archipelago-eval` |
+| `RUN_DYNAMIC_QUEUE` | `0`（`make dynamic-workers` 创建的 VM 会设为 `1`） |
+| `QUEUE_NAME` | `pass5` |
+| `TASK_IDS_GCS_URI` | `gs://<bucket>/<project_dir>/state/task_ids.json` |
+| `NEW_API_SECRET_NAME` | `NEW_API_TOKEN-staging` |
+| `NEW_API_BASE` | `https://new-api-staging.sotalab.ai/v1` |
+
+## Why New API (not direct Gemini/OpenAI)
+
+- 统一入口（OpenAI 兼容）
+- 自带 cache / spend tracking
+- 所有模型（`doubao-seed-2-0-pro-260215` / `qwen3.7-max` 等）走一个 token
+
+`agents/.env` 写入：
+
+```bash
+LITELLM_PROXY_API_BASE=https://new-api-staging.sotalab.ai/v1
+LITELLM_PROXY_API_KEY=<NEW_API_TOKEN-staging from Secret Manager>
+```
+
+注意：`/v1` 结尾很重要，否则 LiteLLM 拼 URL 拼错。
+
+## Required IAM
+
+`vincenthhcui@gmail.com` (你) 在 `sotalab-prod` 项目上需要：
+
+- `roles/compute.admin`
+- `roles/storage.admin`
+- `roles/iam.serviceAccountUser`
+- `roles/secretmanager.secretAccessor` (only on `sotalab-staging`, for the New API token)
+
+## Project Directory Layout (GCS)
+
+```
+gs://sotalab-archipelago-eval/
+└── eval-projects/
+    ├── seed-pro-pass3-20260616/        # 本次评测
+    │   ├── state/
+    │   │   ├── manifest.json           # publish 时写
+    │   │   ├── jobs.json               # publish 时写
+    │   │   ├── task_ids.json           # queue worker 输入
+    │   │   ├── claims/<queue>/         # worker 原子 claim
+    │   │   ├── done/<queue>/           # worker 完成标记
+    │   │   ├── failures/<queue>/       # worker 失败标记
+    │   │   └── summary.json            # aggregate 时写
+    │   ├── results/
+    │   │   └── <task_id>/attempt<N>/
+    │   │       ├── trajectory.json
+    │   │       ├── grades.json
+    │   │       ├── final_snapshot.tar.gz
+    │   │       ├── run.log
+    │   │       └── status.tsv          # 含 run_status / agent_exit / worker_id
+    │   └── logs/
+    │       └── worker-<hostname>.log
+    └── qwen-pass3-20260715/            # 下次评测（隔离）
+        └── ...
+```
+
+## End-to-End Smoke Test (manual)
+
+If you just want to verify the pipeline works:
+
+```bash
+# 1. Pick a short task
+TASK=task_7c394865481b40cdbdd577a039825679
+
+# 2. Write a one-task jobs file and run one static attempt
+printf '[{"task_id":"%s","model":"doubao-seed-2-0-pro-260215"}]\n' "$TASK" \
+  > /tmp/archipelago-smoke-task_ids.json
+gsutil cp /tmp/archipelago-smoke-task_ids.json \
+  gs://sotalab-archipelago-eval/eval-projects/seed-pro-pass3-20260616/state/task_ids.json
+
+python scripts/run_single_task.py \
+  --task-id "$TASK" --attempt 1 \
+  --model doubao-seed-2-0-pro-260215 \
+  --eval-project eval-projects/seed-pro-pass3-20260616 \
+  --bucket sotalab-archipelago-eval \
+  --project-dir eval-projects/seed-pro-pass3-20260616
+
+# 3. Watch the worker
+make status
+
+# 4. Confirm grades.json landed
+gsutil ls gs://sotalab-archipelago-eval/eval-projects/seed-pro-pass3-20260616/results/$TASK/attempt1/
+
+# 5. Aggregate (or just cat summary.json when all done)
+make aggregate
+```

--- a/scripts/add_precision_near_miss_to_report.py
+++ b/scripts/add_precision_near_miss_to_report.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Add numeric precision near-miss diagnostics to a pass@k report."""
+from __future__ import annotations
+
+import argparse
+import collections
+import html
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def pct(value: float | None) -> str:
+    return "N/A" if value is None else f"{value * 100:.2f}%"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def attempt_scores(grades_dir: Path, overrides: set[tuple[str, int, int]]) -> dict[tuple[str, int], float]:
+    scores: dict[tuple[str, int], float] = {}
+    for path in sorted(grades_dir.glob("task_*__attempt*.json")):
+        if path.stat().st_size == 0:
+            continue
+        task_id, attempt_part = path.stem.split("__attempt", 1)
+        attempt = int(attempt_part)
+        payload = load_json(path)
+        verifier_scores = []
+        for index, result in enumerate(payload.get("verifier_results", []) or []):
+            score = float(result.get("score") or 0.0)
+            if (task_id, attempt, index) in overrides:
+                score = 1.0
+            verifier_scores.append(score)
+        if verifier_scores:
+            scores[(task_id, attempt)] = sum(verifier_scores) / len(verifier_scores)
+    return scores
+
+
+def pass_metrics(score_map: dict[tuple[str, int], float], total_tasks: int) -> dict[str, Any]:
+    tasks = sorted({task_id for task_id, _ in score_map})
+
+    def success(score: float | None) -> bool:
+        return score is not None and score >= 0.999999
+
+    pass1 = sum(1 for task_id in tasks if success(score_map.get((task_id, 1))))
+    pass8 = sum(
+        1
+        for task_id in tasks
+        if any(success(score_map.get((task_id, attempt))) for attempt in range(1, 9))
+    )
+    return {
+        "pass1_successes": pass1,
+        "pass1_rate": pass1 / total_tasks if total_tasks else None,
+        "pass8_successes": pass8,
+        "pass8_rate": pass8 / total_tasks if total_tasks else None,
+    }
+
+
+def precision_analysis(
+    precision_payload: dict[str, Any],
+    grades_dir: Path,
+    total_tasks: int,
+) -> dict[str, Any]:
+    globals()["_grades_dir_for_classification"] = grades_dir
+    rows = precision_payload.get("rows", []) or []
+    strict_rows = [row for row in rows if row.get("strict")]
+    small_rows = [row for row in rows if row.get("small")]
+    strict_overrides = {
+        (row["task_id"], int(row["attempt"]), int(row["verifier_index"]))
+        for row in strict_rows
+    }
+    combined_overrides = {
+        (row["task_id"], int(row["attempt"]), int(row["verifier_index"]))
+        for row in rows
+    }
+    original = attempt_scores(grades_dir, set())
+    strict_adjusted = attempt_scores(grades_dir, strict_overrides)
+    combined_adjusted = attempt_scores(grades_dir, combined_overrides)
+
+    original_metrics = pass_metrics(original, total_tasks)
+    strict_metrics = pass_metrics(strict_adjusted, total_tasks)
+    combined_metrics = pass_metrics(combined_adjusted, total_tasks)
+
+    def converted(score_map: dict[tuple[str, int], float]) -> tuple[list[tuple[str, int]], list[str]]:
+        attempts = [
+            key
+            for key, score in original.items()
+            if score < 0.999999 and score_map.get(key, 0.0) >= 0.999999
+        ]
+        original_pass8 = {
+            task_id: any(original.get((task_id, attempt), 0.0) >= 0.999999 for attempt in range(1, 9))
+            for task_id in {task_id for task_id, _ in original}
+        }
+        adjusted_pass8 = {
+            task_id: any(score_map.get((task_id, attempt), 0.0) >= 0.999999 for attempt in range(1, 9))
+            for task_id in {task_id for task_id, _ in original}
+        }
+        newly_passed = sorted(
+            task_id
+            for task_id, passed in original_pass8.items()
+            if not passed and adjusted_pass8.get(task_id)
+        )
+        return attempts, newly_passed
+
+    strict_attempts, strict_new_tasks = converted(strict_adjusted)
+    combined_attempts, combined_new_tasks = converted(combined_adjusted)
+    issue_classes = classify_issue_impact(strict_rows, original, total_tasks)
+
+    top_tasks = [
+        {"task_id": task_id, "count": count}
+        for task_id, count in collections.Counter(row["task_id"] for row in strict_rows).most_common(12)
+    ]
+    diff_buckets = [
+        {"diff": diff, "count": count}
+        for diff, count in collections.Counter(round(float(row["diff"]), 6) for row in strict_rows).most_common()
+    ]
+    examples = [
+        {
+            "task_id": row["task_id"],
+            "attempt": row["attempt"],
+            "required": row["required"]["raw"],
+            "provided": row["provided"]["raw"],
+            "diff": row["diff"],
+            "rationale": row.get("rationale", ""),
+        }
+        for row in strict_rows[:12]
+    ]
+
+    summary = dict(precision_payload.get("summary", {}) or {})
+    summary.update(
+        {
+            "original_metrics": original_metrics,
+            "strict_adjusted_metrics": strict_metrics,
+            "combined_upper_bound_metrics": combined_metrics,
+            "strict_converted_attempts": len(strict_attempts),
+            "strict_converted_tasks": len({task_id for task_id, _ in strict_attempts}),
+            "strict_new_pass8_tasks": strict_new_tasks,
+            "combined_converted_attempts": len(combined_attempts),
+            "combined_converted_tasks": len({task_id for task_id, _ in combined_attempts}),
+            "combined_new_pass8_tasks": combined_new_tasks,
+        }
+    )
+    return {
+        "method": (
+            "Heuristic extraction from grades.json rationale. Strict near-miss means the provided "
+            "number differs from the criterion value by no more than one displayed precision unit "
+            "and relative error <= 0.1%. Small numeric delta is a wider upper-bound bucket."
+        ),
+        "summary": summary,
+        "top_strict_tasks": top_tasks,
+        "strict_diff_buckets": diff_buckets,
+        "strict_examples": examples,
+        "sampled_audit": sampled_audit(),
+        "issue_classification": issue_classes,
+    }
+
+
+def issue_class_by_task() -> dict[str, dict[str, str]]:
+    return {
+        "task_0896a8bf7ee3473d81baa594c05814b3": {
+            "class": "hidden_golden_assumption",
+            "note": "Rubric/gold rounding is inconsistent with audited raw terminal value and revised stake calculation.",
+        },
+        "task_260818eebc2a4366af65fe8f3f17910f": {
+            "class": "hidden_golden_assumption",
+            "note": "Prompt does not specify Open/Close or whether the as-of date is included; gold implies an unstated FDUS median price/window.",
+        },
+        "task_00b30f56f39a4a9891d9503443bafb27": {
+            "class": "hidden_golden_assumption",
+            "note": "Workbook cached values support 2767.4 for Comparables while rubric requires 2767.5.",
+        },
+        "task_883f8bcbf38148648037f16db02a9754": {
+            "class": "hidden_golden_assumption",
+            "note": "Risk-free-rate date/source and exact workbook recalculation path are hidden; all four DCF sensitivities miss by 0.01.",
+        },
+        "task_2802d722ce6d40279fd0931576d2ed88": {
+            "class": "hidden_golden_assumption",
+            "note": "Runner artifacts compute 1843.498, which rounds to 1843; rubric requires 1842.",
+        },
+        "task_a7c1e23437d1451ca11f4ff27105fa40": {
+            "class": "runner_precision",
+            "note": "Prompt specifies VWAP formula; runner/model output lands 0.01 below gold, likely due to workbook/input precision.",
+        },
+        "task_00db129e3bd9497da0acf6470a1d33d2": {
+            "class": "format_rounding_tolerance",
+            "note": "Output includes unrounded and rounded employee metric; this is mostly strict formatting tolerance.",
+        },
+        "task_2b2666310e7e4712be0f2c0e4240d5a2": {
+            "class": "hidden_golden_assumption",
+            "note": "Peer-multiple and actual-equity calculations are exact-value sensitive; prompt does not expose intermediate golden values.",
+        },
+        "task_915931c8aa7840ef9359ce9a50583e3d": {
+            "class": "hidden_golden_assumption",
+            "note": "Target share price differs by one cent after a multi-step REIT valuation with hidden intermediate exact values.",
+        },
+        "task_ac9acf55ae54420fba1675a2985c519e": {
+            "class": "runner_precision",
+            "note": "Gold is supportable using 914.900mm denominator; runner used 914.88mm.",
+        },
+        "task_b8270cca4f7c455791d7b9807ed34295": {
+            "class": "hidden_golden_assumption",
+            "note": "Runner raw breakeven price is 127.345805 -> 127.35; gold likely depends on exact average close/model inputs.",
+        },
+        "task_340d128cb49e4df5952885b707a1cddd": {
+            "class": "ordinary_or_real_error",
+            "note": "Near number appears inside a substantially wrong PF net income result; not a hidden-golden precision issue.",
+        },
+        "task_6137ed8e71c541119bfc2b842364beea": {
+            "class": "hidden_golden_assumption",
+            "note": "Model IRR cell shown in artifacts rounds to 20.43 while rubric requires 20.44.",
+        },
+        "task_658948aa7e6a4ad8af4a73bd76df287c": {
+            "class": "format_rounding_tolerance",
+            "note": "Agent displayed rounded table value while rubric expects a more precise percentage.",
+        },
+        "task_6caba0e23298489cbfc7732bf26ff1e3": {
+            "class": "hidden_golden_assumption",
+            "note": "P/E differs by 0.01 after multiple hidden model inputs and intermediate values.",
+        },
+        "task_7d11f0f8a4ac415599f715647d2a09e4": {
+            "class": "hidden_golden_assumption",
+            "note": "Treasury-rate date/source and workbook recalculation path are hidden; implied share price differs by 0.01.",
+        },
+        "task_a9ce195e45104521ac830136c86d0f69": {
+            "class": "hidden_golden_assumption",
+            "note": "UFCF differs by 0.01 with hidden exact formula/intermediate values.",
+        },
+    }
+
+
+def classify_issue_impact(
+    strict_rows: list[dict[str, Any]],
+    original: dict[tuple[str, int], float],
+    total_tasks: int,
+) -> dict[str, Any]:
+    by_task = issue_class_by_task()
+    by_class: dict[str, dict[str, Any]] = {}
+    for row in strict_rows:
+        task_id = row["task_id"]
+        issue = by_task.get(task_id, {"class": "unclassified", "note": ""})
+        bucket = by_class.setdefault(
+            issue["class"],
+            {
+                "strict_rows": 0,
+                "tasks": set(),
+                "task_attempts": set(),
+                "task_notes": {},
+            },
+        )
+        bucket["strict_rows"] += 1
+        bucket["tasks"].add(task_id)
+        bucket["task_attempts"].add((task_id, int(row["attempt"])))
+        bucket["task_notes"][task_id] = issue["note"]
+
+    class_summaries: dict[str, Any] = {}
+    for issue_class, bucket in by_class.items():
+        overrides = {
+            (row["task_id"], int(row["attempt"]), int(row["verifier_index"]))
+            for row in strict_rows
+            if by_task.get(row["task_id"], {"class": "unclassified"})["class"] == issue_class
+        }
+        adjusted = attempt_scores_from_original(original, overrides)
+        original_metrics = pass_metrics(original, total_tasks)
+        adjusted_metrics = pass_metrics(adjusted, total_tasks)
+        class_summaries[issue_class] = {
+            "strict_rows": bucket["strict_rows"],
+            "tasks": len(bucket["tasks"]),
+            "task_attempts": len(bucket["task_attempts"]),
+            "share_of_strict_rows": bucket["strict_rows"] / len(strict_rows) if strict_rows else None,
+            "pass1_delta": adjusted_metrics["pass1_successes"] - original_metrics["pass1_successes"],
+            "pass8_delta": adjusted_metrics["pass8_successes"] - original_metrics["pass8_successes"],
+            "pass1_adjusted_rate": adjusted_metrics["pass1_rate"],
+            "pass8_adjusted_rate": adjusted_metrics["pass8_rate"],
+            "tasks_detail": [
+                {"task_id": task_id, "note": bucket["task_notes"][task_id]}
+                for task_id in sorted(bucket["tasks"])
+            ],
+        }
+    return {
+        "method": (
+            "Manual conservative classification of strict numeric near-miss tasks based on prompt, "
+            "gold/rubric, grader rationale, and sampled runner artifacts. hidden_golden_assumption "
+            "means the prompt/gold omits a source, date-window, input precision, or intermediate "
+            "rounding rule needed to reproduce the exact value."
+        ),
+        "by_class": class_summaries,
+    }
+
+
+def attempt_scores_from_original(
+    original: dict[tuple[str, int], float],
+    overrides: set[tuple[str, int, int]],
+) -> dict[tuple[str, int], float]:
+    # Recompute from grade files because original stores aggregate attempt scores.
+    # This helper is patched in main by assigning _grades_dir_for_classification.
+    grades_dir = globals().get("_grades_dir_for_classification")
+    if not isinstance(grades_dir, Path):
+        return original
+    return attempt_scores(grades_dir, overrides)
+
+
+def sampled_audit() -> list[dict[str, str]]:
+    return [
+        {
+            "task_id": "task_00b30f56f39a4a9891d9503443bafb27",
+            "classification": "gold / rubric questionable",
+            "evidence": (
+                "Workbook cached values support raw Comparables 2767.4469, which rounds to 2767.4. "
+                "The rubric's 2767.5 is not supported by the audited calculation; the related mean "
+                "3030.8 is supportable if computed from raw values."
+            ),
+        },
+        {
+            "task_id": "task_0896a8bf7ee3473d81baa594c05814b3",
+            "classification": "likely gold rounding inconsistency",
+            "evidence": (
+                "Run log computes discounted terminal value 19959.097, which rounds to 19959.1, while "
+                "the rubric requires 19959.0. The same calculation still supports the rubric's revised "
+                "stake value of 4949.8."
+            ),
+        },
+        {
+            "task_id": "task_b8270cca4f7c455791d7b9807ed34295",
+            "classification": "likely input-source / golden ambiguity",
+            "evidence": (
+                "The selected verification calculation gives raw 127.345805, which rounds to 127.35; "
+                "the rubric requires 127.36. This likely depends on exact share-price source or cached "
+                "model inputs, not a clear model reasoning failure."
+            ),
+        },
+        {
+            "task_id": "task_ac9acf55ae54420fba1675a2985c519e",
+            "classification": "runner intermediate precision issue",
+            "evidence": (
+                "Workbook denominator is 914900 thousand. Using it gives Base 55.91% and Bull 91.61%, "
+                "matching gold. The runner appears to use 914.88 million, producing 55.92% and 91.62%."
+            ),
+        },
+        {
+            "task_id": "task_260818eebc2a4366af65fe8f3f17910f",
+            "classification": "runner rounded inputs before division",
+            "evidence": (
+                "The run log divides displayed prices 20.57 / 8.74 = 2.3535469, rounding to 2.354. "
+                "Gold's 2.355 likely uses more precise underlying share prices, so this is an "
+                "intermediate precision or input extraction issue."
+            ),
+        },
+        {
+            "task_id": "task_a006f24d413c4dc99dd644d5e0dc12f7",
+            "classification": "scanner false positive / real runner miss",
+            "evidence": (
+                "This case was removed by the corrected scanner. The runner calculated 22.02 while the "
+                "rubric required 22.41, so it is not a precision near-miss."
+            ),
+        },
+    ]
+
+
+def render_section(analysis: dict[str, Any]) -> str:
+    summary = analysis["summary"]
+    original = summary["original_metrics"]
+    strict = summary["strict_adjusted_metrics"]
+    combined = summary["combined_upper_bound_metrics"]
+    top_rows = "\n".join(
+        "<tr>"
+        f"<td><code>{html.escape(row['task_id'])}</code></td>"
+        f"<td>{row['count']}</td>"
+        "</tr>"
+        for row in analysis["top_strict_tasks"]
+    )
+    bucket_rows = "\n".join(
+        "<tr>"
+        f"<td>{row['diff']}</td>"
+        f"<td>{row['count']}</td>"
+        "</tr>"
+        for row in analysis["strict_diff_buckets"]
+    )
+    example_rows = "\n".join(
+        "<tr>"
+        f"<td><code>{html.escape(row['task_id'])}</code></td>"
+        f"<td>{html.escape(str(row['attempt']))}</td>"
+        f"<td>{html.escape(str(row['provided']))}</td>"
+        f"<td>{html.escape(str(row['required']))}</td>"
+        f"<td>{html.escape(str(round(float(row['diff']), 6)))}</td>"
+        f"<td>{html.escape(row['rationale'])}</td>"
+        "</tr>"
+        for row in analysis["strict_examples"]
+    )
+    audit_rows = "\n".join(
+        "<tr>"
+        f"<td><code>{html.escape(row['task_id'])}</code></td>"
+        f"<td>{html.escape(row['classification'])}</td>"
+        f"<td>{html.escape(row['evidence'])}</td>"
+        "</tr>"
+        for row in analysis.get("sampled_audit", [])
+    )
+    issue_classes = analysis.get("issue_classification", {}).get("by_class", {})
+    issue_order = [
+        "hidden_golden_assumption",
+        "runner_precision",
+        "format_rounding_tolerance",
+        "ordinary_or_real_error",
+        "unclassified",
+    ]
+    issue_rows = "\n".join(
+        "<tr>"
+        f"<td>{html.escape(issue_class)}</td>"
+        f"<td>{bucket['strict_rows']}</td>"
+        f"<td>{bucket['tasks']}</td>"
+        f"<td>{pct(bucket.get('share_of_strict_rows'))}</td>"
+        f"<td>+{bucket['pass1_delta']}</td>"
+        f"<td>+{bucket['pass8_delta']}</td>"
+        f"<td>{pct(bucket.get('pass8_adjusted_rate'))}</td>"
+        "</tr>"
+        for issue_class in issue_order
+        if (bucket := issue_classes.get(issue_class))
+    )
+    hidden_details = ""
+    hidden_bucket = issue_classes.get("hidden_golden_assumption", {})
+    if hidden_bucket:
+        hidden_details = "\n".join(
+            "<tr>"
+            f"<td><code>{html.escape(row['task_id'])}</code></td>"
+            f"<td>{html.escape(row['note'])}</td>"
+            "</tr>"
+            for row in hidden_bucket.get("tasks_detail", [])
+        )
+    strict_delta_pass1 = strict["pass1_successes"] - original["pass1_successes"]
+    strict_delta_pass8 = strict["pass8_successes"] - original["pass8_successes"]
+    combined_delta_pass1 = combined["pass1_successes"] - original["pass1_successes"]
+    combined_delta_pass8 = combined["pass8_successes"] - original["pass8_successes"]
+    return f"""
+<!-- precision-near-miss:start -->
+<section class="panel" style="margin-top:16px"><h2>Precision Near-Miss 影响范围</h2>
+<p class="note">{html.escape(analysis["method"])}</p>
+<div class="grid metrics">
+<div class="panel"><div class="label">strict near-miss</div><div class="value info">{summary['strict_precision_near_miss']}</div><div class="sub">failed verifier 占比 {pct(summary['strict_share_failed'])}；涉及 {summary['strict_unique_tasks']} 个 task</div></div>
+<div class="panel"><div class="label">small delta 上界</div><div class="value info">{summary['combined_strict_plus_small']}</div><div class="sub">failed verifier 占比 {pct(summary['combined_share_failed'])}</div></div>
+<div class="panel"><div class="label">pass@1 调整</div><div class="value ok">{pct(strict['pass1_rate'])}</div><div class="sub">原始 {pct(original['pass1_rate'])}；strict +{strict_delta_pass1} tasks，上界 +{combined_delta_pass1}</div></div>
+<div class="panel"><div class="label">pass@8 调整</div><div class="value ok">{pct(strict['pass8_rate'])}</div><div class="sub">原始 {pct(original['pass8_rate'])}；strict +{strict_delta_pass8} tasks，上界 +{combined_delta_pass8}</div></div>
+<div class="panel"><div class="label">新通过 task</div><div class="value">{len(summary['strict_new_pass8_tasks'])}</div><div class="sub">strict 口径；上界 {len(summary['combined_new_pass8_tasks'])}</div></div>
+</div>
+<div class="callout">这些调整是诊断口径，不替代正式 pass@k。它用于衡量 exact numeric rubric 对边界 rounding / golden ambiguity 的影响。</div>
+<div class="callout">抽查结论：Precision Near-Miss 不是全部由 golden 不合理导致。样本中同时存在 gold / rubric rounding inconsistency、runner 中间精度或输入源问题，以及扫描误报。</div>
+<h2 style="margin-top:16px">Hidden Golden Assumption 影响</h2>
+<p class="note">{html.escape(analysis.get("issue_classification", {}).get("method", ""))}</p>
+<table class="compact"><thead><tr><th>class</th><th>strict rows</th><th>tasks</th><th>占 strict</th><th>pass@1 delta</th><th>pass@8 delta</th><th>class-only pass@8</th></tr></thead><tbody>{issue_rows}</tbody></table>
+<h2 style="margin-top:16px">hidden_golden_assumption task 明细</h2>
+<table class="compact"><thead><tr><th>task</th><th>evidence / note</th></tr></thead><tbody>{hidden_details}</tbody></table>
+<section class="grid two" style="margin-top:16px">
+<div><h2>高频 strict near-miss task</h2><table><thead><tr><th>task</th><th>failed verifiers</th></tr></thead><tbody>{top_rows}</tbody></table></div>
+<div><h2>误差分布</h2><table><thead><tr><th>abs diff</th><th>failed verifiers</th></tr></thead><tbody>{bucket_rows}</tbody></table></div>
+</section>
+<h2 style="margin-top:16px">抽查分类</h2>
+<table class="compact"><thead><tr><th>task</th><th>classification</th><th>evidence</th></tr></thead><tbody>{audit_rows}</tbody></table>
+<h2 style="margin-top:16px">strict near-miss 样例</h2>
+<table class="compact"><thead><tr><th>task</th><th>attempt</th><th>provided</th><th>required</th><th>diff</th><th>evidence snippet</th></tr></thead><tbody>{example_rows}</tbody></table>
+</section>
+<!-- precision-near-miss:end -->
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report-json", required=True)
+    parser.add_argument("--report-html", required=True)
+    parser.add_argument("--precision-json", required=True)
+    parser.add_argument("--grades-dir", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-html", required=True)
+    args = parser.parse_args()
+
+    report_json = Path(args.report_json)
+    report_html = Path(args.report_html)
+    precision_json = Path(args.precision_json)
+    grades_dir = Path(args.grades_dir)
+    output_json = Path(args.output_json)
+    output_html = Path(args.output_html)
+
+    report = load_json(report_json)
+    precision_payload = load_json(precision_json)
+    analysis = precision_analysis(precision_payload, grades_dir, int(report["total_tasks"]))
+    report["precision_near_miss_analysis"] = analysis
+    output_json.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+    html_text = report_html.read_text()
+    section = render_section(analysis)
+    marker = '<section class="panel" style="margin-top:16px"><h2>Trajectory 样本验证</h2>'
+    while "<!-- precision-near-miss:start -->" in html_text and "<!-- precision-near-miss:end -->" in html_text:
+        start = html_text.index("<!-- precision-near-miss:start -->")
+        end = html_text.index("<!-- precision-near-miss:end -->", start) + len("<!-- precision-near-miss:end -->")
+        html_text = html_text[:start] + html_text[end:]
+    legacy_marker = '<section class="panel" style="margin-top:16px"><h2>Precision Near-Miss 影响范围</h2>'
+    while legacy_marker in html_text and marker in html_text:
+        start = html_text.index(legacy_marker)
+        end = html_text.index(marker, start)
+        html_text = html_text[:start] + html_text[end:]
+    if marker in html_text:
+        html_text = html_text.replace(marker, section + "\n" + marker, 1)
+    else:
+        html_text = html_text.replace("</main></body></html>", section + "\n</main></body></html>")
+    output_html.write_text(html_text)
+    print(json.dumps(analysis["summary"], ensure_ascii=False, indent=2))
+    print(f"html={output_html}")
+    print(f"json={output_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+One-shot aggregator: download all grades.json from GCS, compute
+pass@1 / pass@k / mean score, write summary.json.
+
+Usage:
+    python scripts/aggregate_results.py [--project-dir ...] [--bucket ...]
+
+Reads jobs from local ~/.archipelago-eval/<project>/jobs.json (written by
+local_scheduler.py publish) and pulls grades.json from GCS results/ tree.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from google.cloud import storage
+
+PROJECT_DIR_DEFAULT = "eval-projects/seed-pro-pass3-20260616"
+BUCKET_DEFAULT = "sotalab-archipelago-eval"
+PROJECT_DEFAULT = "sotalab-prod"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def local_state_dir(project_dir: str) -> Path:
+    return Path.home() / ".archipelago-eval" / project_dir.replace("/", "__")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project-dir", default=PROJECT_DIR_DEFAULT)
+    ap.add_argument("--bucket", default=BUCKET_DEFAULT)
+    ap.add_argument("--project", default=PROJECT_DEFAULT)
+    ap.add_argument("--k", type=int, default=None,
+                    help="Total attempts per task (overrides jobs.json)")
+    args = ap.parse_args()
+
+    state_dir = local_state_dir(args.project_dir)
+    jobs_path = state_dir / "jobs.json"
+    if not jobs_path.exists():
+        print(f"missing {jobs_path}; run local_scheduler.py publish first")
+        return 1
+
+    jobs = json.loads(jobs_path.read_text())
+    if args.k is None:
+        args.k = max(
+            (j["attempt"] for j in jobs),
+            default=0,
+        )
+
+    client = storage.Client(project=args.project)
+    bucket = client.bucket(args.bucket)
+
+    by_task: dict[str, list[dict]] = collections.defaultdict(list)
+    for j in jobs:
+        gp = f"{args.project_dir}/results/{j['task_id']}/attempt{j['attempt']}/grades.json"
+        blob = bucket.blob(gp)
+        if blob.exists():
+            g = json.loads(blob.download_as_text())
+            score = g.get("scoring_results", {}).get("final_score")
+        else:
+            score = None
+        by_task[j["task_id"]].append({"attempt": j["attempt"], "score": score})
+
+    rows = []
+    for tid, runs in sorted(by_task.items()):
+        scores = [r["score"] for r in runs if isinstance(r["score"], (int, float))]
+        n = len(scores)
+        if n == 0:
+            rows.append({
+                "task_id": tid, "n_scored": 0,
+                "pass_at_1": None, "pass_at_k": 0, "mean_score": None,
+                "scores": [],
+            })
+            continue
+        pass_1 = sum(1 for s in scores if s >= 1.0) / n
+        pass_k = 1 if any(s >= 1.0 for s in scores) else 0
+        mean = sum(scores) / n
+        rows.append({
+            "task_id": tid, "n_scored": n,
+            "pass_at_1": pass_1, "pass_at_k": pass_k,
+            "mean_score": mean, "scores": scores,
+        })
+
+    n_scored = sum(r["n_scored"] for r in rows)
+    overall_pass1 = (sum(r["pass_at_1"] * r["n_scored"]
+                         for r in rows) / n_scored) if n_scored else 0
+    overall_passk = (sum(r["pass_at_k"] for r in rows) / len(rows)) if rows else 0
+    overall_mean = (sum(r["mean_score"] * r["n_scored"]
+                        for r in rows) / n_scored) if n_scored else 0
+
+    out = {
+        "generated_at": now_iso(),
+        "project_dir": args.project_dir,
+        "model": jobs[0]["model"] if jobs else None,
+        "k": args.k,
+        "per_task": rows,
+        "overall": {
+            "pass_at_1": overall_pass1,
+            "pass_at_k": overall_passk,
+            "mean_score": overall_mean,
+            "n_attempts_scored": n_scored,
+        },
+    }
+
+    out_local = state_dir / "summary.json"
+    out_local.write_text(json.dumps(out, indent=2))
+
+    # CSV sibling (paste-into-spreadsheet friendly)
+    csv_path = state_dir / "summary.csv"
+    with csv_path.open("w") as f:
+        f.write("task_id,n_scored,pass_at_1,pass_at_k,mean_score,scores\n")
+        for r in rows:
+            p1 = "" if r["pass_at_1"] is None else f"{r['pass_at_1']:.4f}"
+            mn = "" if r["mean_score"] is None else f"{r['mean_score']:.4f}"
+            f.write(
+                f"{r['task_id']},{r['n_scored']},{p1},{r['pass_at_k']},{mn},"
+                f"\"{';'.join(f'{s:.2f}' for s in r['scores'])}\"\n"
+            )
+        f.write(
+            f"OVERALL,{n_scored},{overall_pass1:.4f},"
+            f"{overall_passk:.4f},{overall_mean:.4f},\"\n"
+        )
+
+    out_gcs = bucket.blob(f"{args.project_dir}/state/summary.json")
+    out_gcs.upload_from_string(
+        json.dumps(out, indent=2), content_type="application/json"
+    )
+    bucket.blob(f"{args.project_dir}/state/summary.csv").upload_from_string(
+        csv_path.read_text(), content_type="text/csv"
+    )
+
+    print(f"\n=== AGGREGATE  ({now_iso()}) ===")
+    print(f"  {'task_id':<50} {'pass@1':<8} {'pass@k':<8} {'mean':<6}")
+    print("  " + "-" * 80)
+    for r in rows:
+        p1 = f"{r['pass_at_1']:.2f}" if r["pass_at_1"] is not None else "—"
+        pk = f"{r['pass_at_k']:.2f}" if r["pass_at_k"] is not None else "—"
+        mn = f"{r['mean_score']:.2f}" if r["mean_score"] is not None else "—"
+        print(f"  {r['task_id']:<50} {p1:<8} {pk:<8} {mn:<6}")
+    print(
+        f"\n  OVERALL  pass@1={overall_pass1:.2f}  "
+        f"pass@k={overall_passk:.2f}  mean={overall_mean:.2f}  "
+        f"(n_scored={n_scored})"
+    )
+    print(f"\n  summary.json -> {out_local}")
+    print(f"  gs://{args.bucket}/{args.project_dir}/state/summary.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval_worker.py
+++ b/scripts/eval_worker.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Archipelago eval worker — runs on each GCE VM.
+
+Subscribes to PUBSUB_SUBSCRIPTION, processes one job at a time:
+  1. Idempotency check: skip if results/{task}/attempt{N}/grades.json exists
+  2. Force rerun: if force_rerun=true, rm -r the result dir before running
+  3. Run scripts/run_single_task.py
+  4. Upload results to GCS (handled by run_single_task.py)
+  5. Ack the Pub/Sub message
+
+Required env vars (set by setup_worker.sh via /etc/archipelago-eval.env):
+  ARCHIPELAGO_DIR, EVAL_PROJECT_DIR, EVAL_BUCKET, PUBSUB_SUBSCRIPTION,
+  PUBSUB_PROJECT
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger(f"eval_worker.{socket.gethostname()}")
+
+ARCHIPELAGO_DIR = Path(os.environ.get("ARCHIPELAGO_DIR", "/opt/archipelago"))
+EVAL_PROJECT_DIR = os.environ.get("EVAL_PROJECT_DIR", "eval-projects/seed-pro-pass3-20260616")
+EVAL_BUCKET = os.environ.get("EVAL_BUCKET", "sotalab-archipelago-eval")
+PUBSUB_SUBSCRIPTION = os.environ.get("PUBSUB_SUBSCRIPTION", "archipelago-eval-workers")
+PUBSUB_PROJECT = os.environ.get("PUBSUB_PROJECT", "sotalab-staging")
+
+WORKER_ID = socket.gethostname()
+SUB_NAME = (
+    f"projects/{PUBSUB_PROJECT}/subscriptions/{PUBSUB_SUBSCRIPTION}"
+)
+
+# In-memory ack deadline extender state
+ack_state: dict[str, dict[str, Any]] = {}
+
+
+def gcs_results_path(task_id: str, attempt: int) -> str:
+    return (
+        f"gs://{EVAL_BUCKET}/{EVAL_PROJECT_DIR}/results/{task_id}/attempt{attempt}"
+    )
+
+
+def gcs_results_url(task_id: str, attempt: int) -> str:
+    return gcs_results_path(task_id, attempt) + "/"
+
+
+def gcs_exists(gs_url: str) -> bool:
+    res = subprocess.run(
+        ["gsutil", "-q", "stat", gs_url],
+        capture_output=True,
+    )
+    return res.returncode == 0
+
+
+def gcs_gsutil(*args: str) -> int:
+    return subprocess.run(["gsutil", *args]).returncode
+
+
+def is_already_done(task_id: str, attempt: int) -> bool:
+    """Skip job if grades.json + status.tsv already exist in GCS."""
+    grades = gcs_results_path(task_id, attempt) + "/grades.json"
+    status = gcs_results_path(task_id, attempt) + "/status.tsv"
+    if not (gcs_exists(grades) and gcs_exists(status)):
+        return False
+    # Quick check: status.tsv should report run_status=completed
+    try:
+        res = subprocess.run(
+            ["gsutil", "cat", status], capture_output=True, text=True
+        )
+        for line in res.stdout.splitlines():
+            if line.startswith("run_status\t"):
+                return line.split("\t", 1)[1].strip() == "completed"
+    except Exception as e:
+        log.warning("status.tsv read failed: %s", e)
+    return False
+
+
+def clear_history(task_id: str, attempt: int) -> None:
+    """gsutil rm -r the result dir, also wipe local output."""
+    log.info("force_rerun: clearing %s", gcs_results_url(task_id, attempt))
+    subprocess.run(
+        ["gsutil", "-m", "-q", "rm", "-r", gcs_results_url(task_id, attempt)],
+        capture_output=True,
+    )
+    local = (
+        ARCHIPELAGO_DIR
+        / "examples"
+        / "hugging_face_task"
+        / "output"
+        / task_id
+        / f"attempt{attempt}"
+    )
+    if local.exists():
+        subprocess.run(["rm", "-rf", str(local)], check=False)
+
+
+def run_single_task(job: dict[str, Any]) -> int:
+    cmd = [
+        "python3",
+        str(ARCHIPELAGO_DIR / "scripts" / "run_single_task.py"),
+        "--task-id", job["task_id"],
+        "--model", job["model"],
+        "--attempt", str(job["attempt"]),
+        "--worker-id", WORKER_ID,
+        "--eval-project", EVAL_PROJECT_DIR,
+        "--bucket", EVAL_BUCKET,
+        "--project-dir", EVAL_PROJECT_DIR,
+    ]
+    if job.get("force_rerun") or job.get("rerun"):
+        cmd.append("--rerun")
+    log.info("running: %s", " ".join(cmd))
+    return subprocess.run(cmd, cwd=ARCHIPELAGO_DIR).returncode
+
+
+def start_ack_extender(subscriber, subscription_path, ack_id, deadline_sec=300):
+    """Periodically extend ack deadline while a job is running."""
+    stop = threading.Event()
+
+    def loop():
+        while not stop.wait(60):
+            try:
+                subscriber.modify_ack_deadline(
+                    subscription=subscription_path,
+                    ack_ids=[ack_id],
+                    ack_deadline_seconds=deadline_sec,
+                )
+            except Exception as e:
+                log.warning("extend ack failed: %s", e)
+
+    t = threading.Thread(target=loop, daemon=True)
+    t.start()
+    return stop
+
+
+def vm_is_busy() -> bool:
+    """Return True if a main.py agent run is already in progress on this VM.
+
+    Used to avoid clobbering an in-flight SSH-dispatched agent run when a
+    Pub/Sub job arrives simultaneously. We check by looking for an active
+    main.py process under the examples/hugging_face_task directory.
+    """
+    try:
+        res = subprocess.run(
+            ["pgrep", "-f", "examples/hugging_face_task/main.py"],
+            capture_output=True, text=True,
+        )
+        return bool(res.stdout.strip())
+    except Exception:
+        return False
+
+
+def process_message(subscriber, message) -> None:
+    payload = message.data.decode("utf-8")
+    try:
+        job = json.loads(payload)
+    except json.JSONDecodeError:
+        log.error("invalid JSON, dropping: %s", payload[:200])
+        message.ack()
+        return
+
+    task_id = job["task_id"]
+    attempt = int(job["attempt"])
+    model = job.get("model", "?")
+    force = bool(job.get("force_rerun"))
+
+    log.info(
+        "JOB received: task=%s model=%s attempt=%d force_rerun=%s",
+        task_id, model, attempt, force,
+    )
+
+    # If another agent is already running on this VM (e.g. SSH-dispatched),
+    # nack with a small delay so another worker can pick it up.
+    if vm_is_busy() and not force:
+        log.warning(
+            "VM busy with another agent run; nacking %s attempt %d for re-delivery",
+            task_id, attempt,
+        )
+        message.nack()
+        return
+
+    if force:
+        clear_history(task_id, attempt)
+    elif is_already_done(task_id, attempt):
+        log.info(
+            "SKIP: results exist for %s attempt %d (idempotent)",
+            task_id, attempt,
+        )
+        message.ack()
+        return
+
+    extender = start_ack_extender(
+        subscriber, SUB_NAME, message.ack_id, deadline_sec=600
+    )
+    try:
+        rc = run_single_task(job)
+        log.info("JOB finished: task=%s attempt=%d rc=%d", task_id, attempt, rc)
+    except Exception as e:
+        log.exception("JOB crashed: %s", e)
+    finally:
+        extender.set()
+
+    message.ack()
+
+
+def main() -> int:
+    try:
+        from google.cloud import pubsub_v1
+    except ImportError:
+        log.error("google-cloud-pubsub not installed; aborting")
+        return 1
+
+    log.info("worker starting: worker_id=%s subscription=%s", WORKER_ID, SUB_NAME)
+
+    # Periodically tail GCS log file as well
+    client = pubsub_v1.SubscriberClient()
+    flow_control = pubsub_v1.types.FlowControl(max_messages=1)
+
+    while True:
+        try:
+            future = client.subscribe(
+                SUB_NAME,
+                callback=lambda msg: process_message(client, msg),
+                flow_control=flow_control,
+            )
+            log.info("subscribed; waiting for messages")
+            future.result()  # blocks; raises on error
+        except KeyboardInterrupt:
+            log.info("interrupt received, shutting down")
+            future.cancel()
+            return 0
+        except Exception as e:
+            log.exception("subscribe loop error: %s; retrying in 10s", e)
+            time.sleep(10)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_passk_report.py
+++ b/scripts/generate_passk_report.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+"""
+Generate a staged pass@k report from GCS result artifacts.
+
+The report intentionally separates:
+  - pass@1 over completed attempt1 tasks
+  - any-attempt pass rate over tasks with any completed attempt
+  - prefix pass@k over tasks that have attempts 1..k completed
+
+Some failed runs upload status.tsv and trajectory.json but intentionally skip
+grades.json. Those attempts are real completed attempts and must count as 0,
+otherwise pass@k is biased upward by silently dropping failures.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import concurrent.futures
+import html
+import json
+import math
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    from google.cloud import storage
+except ModuleNotFoundError:  # pragma: no cover - user-facing dependency hint
+    storage = None
+
+
+ARTIFACT_RE = re.compile(r"/results/(task_[^/]+)/attempt(\d+)/(status\.tsv|grades\.json|trajectory\.json)$")
+GRADE_RE = re.compile(r"/results/(task_[^/]+)/attempt(\d+)/grades\.json$")
+PRICE_VALUE_RE = re.compile(
+    r"\b("
+    r"price|share price|per share|offer price|purchase price|trading price|target price|"
+    r"valuation|value|enterprise value|equity value|market cap|ev|dcf|lbo|"
+    r"multiple|ev/ebitda|irr|moic|accretion|dilution"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+FAILURE_CATEGORY_LABELS = {
+    "artifact_output_incomplete": "Artifact / final output 不完整",
+    "numeric_finance_mismatch": "财务数值不匹配",
+    "spreadsheet_formula_state_error": "Spreadsheet 公式 / 状态错误",
+    "cannot_complete_or_data_not_found": "数据发现失败 / cannot complete",
+    "missing_required_detail": "漏掉 rubric 要求细节",
+    "wrong_conclusion": "结论方向错误",
+    "other": "其他 judge failure",
+}
+
+
+def classify_failure_rationale(rationale: str) -> str:
+    low = rationale.lower()
+    if (
+        "cannot complete" in low
+        or "no access" in low
+        or "not available in the sandbox" in low
+        or "failed to complete" in low
+    ):
+        return "cannot_complete_or_data_not_found"
+    if "#value!" in low or "formula error" in low:
+        return "spreadsheet_formula_state_error"
+    if (
+        any(
+            marker in low
+            for marker in (
+                "instead of the required",
+                "does not match",
+                "rather than the required",
+                "provided a value",
+                "reported",
+            )
+        )
+        and any(
+            term in low
+            for term in (
+                "irr",
+                "cagr",
+                "equity value",
+                "enterprise value",
+                "share price",
+                "ebitda",
+                "revenue",
+                "price",
+                "moic",
+                "capex",
+                "wacc",
+                "dcf",
+                "lbo",
+            )
+        )
+    ):
+        return "numeric_finance_mismatch"
+    if any(marker in low for marker in ("does not mention", "omits", "not explicitly", "fails to state", "does not state")):
+        return "missing_required_detail"
+    if (
+        any(term in low for term in ("created file", "artifact", "document", "spreadsheet", "sheet"))
+        and any(marker in low for marker in ("not met", "does not contain", "missing"))
+    ):
+        return "artifact_output_incomplete"
+    if any(marker in low for marker in ("contradicts", "incorrectly concludes", "concluded that")):
+        return "wrong_conclusion"
+    return "other"
+
+
+def pct(value: float | None) -> str:
+    return "N/A" if value is None else f"{value * 100:.2f}%"
+
+
+def num(value: float | None) -> str:
+    return "N/A" if value is None else f"{value:.3f}"
+
+
+def require_storage() -> Any:
+    if storage is None:
+        raise SystemExit(
+            "Missing dependency google-cloud-storage. Install with:\n"
+            "  python3 -m venv /tmp/gcs-report-venv\n"
+            "  /tmp/gcs-report-venv/bin/pip install google-cloud-storage\n"
+            "  /tmp/gcs-report-venv/bin/python scripts/generate_passk_report.py ..."
+        )
+    return storage
+
+
+def list_result_blobs(client: Any, bucket_name: str, project_dir: str) -> list[str]:
+    prefix = f"{project_dir}/results/"
+    names = []
+    for blob in client.list_blobs(bucket_name, prefix=prefix):
+        if ARTIFACT_RE.search("/" + blob.name):
+            names.append(blob.name)
+    return names
+
+
+def read_grade(
+    bucket: Any,
+    blob_name: str,
+) -> tuple[str, int, float, float | None, int, dict[str, int], int, int, dict[str, str]] | None:
+    match = GRADE_RE.search("/" + blob_name)
+    if not match:
+        return None
+    task_id = match.group(1)
+    attempt = int(match.group(2))
+    try:
+        payload = json.loads(bucket.blob(blob_name).download_as_text())
+        score = payload.get("scoring_results", {}).get("final_score")
+        price_scores = []
+        failure_categories: collections.Counter[str] = collections.Counter()
+        failure_examples: dict[str, str] = {}
+        verifier_total = 0
+        verifier_failed = 0
+        for result in payload.get("verifier_results", []) or []:
+            verifier_total += 1
+            values = result.get("verifier_result_values", {}) or {}
+            haystack = "\n".join(
+                str(values.get(key, ""))
+                for key in ("grade_rationale", "evaluated_artifacts", "judge_grade")
+            )
+            if PRICE_VALUE_RE.search(haystack):
+                result_score = result.get("score")
+                if result_score is not None:
+                    price_scores.append(float(result_score))
+            result_score = result.get("score")
+            if result_score is not None and float(result_score) < 1.0:
+                verifier_failed += 1
+                category = classify_failure_rationale(str(values.get("grade_rationale", "")))
+                failure_categories[category] += 1
+                failure_examples.setdefault(
+                    category,
+                    re.sub(r"\s+", " ", str(values.get("grade_rationale", ""))).strip()[:320],
+                )
+    except Exception:
+        return None
+    if score is None:
+        return None
+    price_score = sum(price_scores) / len(price_scores) if price_scores else None
+    return (
+        task_id,
+        attempt,
+        float(score),
+        price_score,
+        len(price_scores),
+        dict(failure_categories),
+        verifier_total,
+        verifier_failed,
+        failure_examples,
+    )
+
+
+def aggregate(
+    rows: list[tuple[str, int, float, float | None, int, dict[str, int], int, int, dict[str, str]]],
+    total_tasks: int,
+    completed_without_grades: list[tuple[str, int]],
+) -> dict[str, Any]:
+    by_task: dict[str, dict[int, float]] = collections.defaultdict(dict)
+    price_by_task: dict[str, dict[int, dict[str, float | int]]] = collections.defaultdict(dict)
+    verifier_failure_categories: collections.Counter[str] = collections.Counter()
+    verifier_failure_examples: dict[str, dict[str, str]] = {}
+    attempt_primary_categories: collections.Counter[str] = collections.Counter()
+    attempt_primary_scores: dict[str, list[float]] = collections.defaultdict(list)
+    verifier_total_count = 0
+    verifier_failed_count = 0
+    for task_id, attempt, score, price_score, price_count, failure_categories, verifier_total, verifier_failed, failure_examples in rows:
+        by_task[task_id][attempt] = max(score, by_task[task_id].get(attempt, -1.0))
+        if price_score is not None:
+            existing = price_by_task[task_id].get(attempt)
+            if existing is None or price_score > float(existing["score"]):
+                price_by_task[task_id][attempt] = {"score": price_score, "n": price_count}
+        verifier_total_count += verifier_total
+        verifier_failed_count += verifier_failed
+        verifier_failure_categories.update(failure_categories)
+        for category, example in failure_examples.items():
+            verifier_failure_examples.setdefault(
+                category,
+                {
+                    "task_id": task_id,
+                    "attempt": attempt,
+                    "example": example,
+                },
+            )
+        if failure_categories:
+            primary_category = collections.Counter(failure_categories).most_common(1)[0][0]
+        else:
+            primary_category = "pass"
+        attempt_primary_categories[primary_category] += 1
+        attempt_primary_scores[primary_category].append(score)
+
+    by_attempt: collections.Counter[int] = collections.Counter()
+    success_by_attempt: collections.Counter[int] = collections.Counter()
+    score_bins: collections.Counter[str] = collections.Counter()
+    for attempts in by_task.values():
+        for attempt, score in attempts.items():
+            by_attempt[attempt] += 1
+            if score >= 1.0:
+                success_by_attempt[attempt] += 1
+            if score == 0:
+                score_bins["0"] += 1
+            elif score < 0.5:
+                score_bins["0-<0.5"] += 1
+            elif score < 0.8:
+                score_bins["0.5-<0.8"] += 1
+            elif score < 1.0:
+                score_bins["0.8-<1"] += 1
+            else:
+                score_bins["1.0"] += 1
+
+    scores = [score for attempts in by_task.values() for score in attempts.values()]
+    success_tasks = {
+        task_id for task_id, attempts in by_task.items() if any(score >= 1.0 for score in attempts.values())
+    }
+
+    pass1_denom = by_attempt[1]
+    pass1_successes = success_by_attempt[1]
+    attempt1_scores = [attempts[1] for attempts in by_task.values() if 1 in attempts]
+
+    per_k = []
+    max_attempt = max(max((attempts.keys()), default=0) for attempts in by_task.values()) if by_task else 0
+    for k in range(1, max(8, max_attempt) + 1):
+        eligible = [
+            (task_id, attempts)
+            for task_id, attempts in by_task.items()
+            if all(i in attempts for i in range(1, k + 1))
+        ]
+        successes = sum(
+            1 for _, attempts in eligible if any(attempts[i] >= 1.0 for i in range(1, k + 1))
+        )
+        best_scores = [max(attempts[i] for i in range(1, k + 1)) for _, attempts in eligible]
+        per_k.append(
+            {
+                "k": k,
+                "n_tasks_with_1_to_k": len(eligible),
+                "successes": successes,
+                "pass_at_k": successes / len(eligible) if eligible else None,
+                "lower_bound_all_tasks": successes / total_tasks,
+                "mean_best_score": sum(best_scores) / len(best_scores) if best_scores else None,
+            }
+        )
+
+    return {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "total_tasks": total_tasks,
+        "scored_tasks": len(by_task),
+        "scored_attempts": len(scores),
+        "attempt_counts": {str(i): by_attempt[i] for i in range(1, max(8, max_attempt) + 1)},
+        "success_by_attempt": {str(i): success_by_attempt[i] for i in range(1, max(8, max_attempt) + 1)},
+        "pass_at_1_attempt1_only": {
+            "tasks_with_attempt1_grade": pass1_denom,
+            "successes": pass1_successes,
+            "observed_on_attempt1_graded_tasks": pass1_successes / pass1_denom if pass1_denom else None,
+            "lower_bound_all_tasks": pass1_successes / total_tasks,
+            "mean_attempt1_score": sum(attempt1_scores) / len(attempt1_scores) if attempt1_scores else None,
+        },
+        "current_any_attempt_pass_rate": {
+            "scored_task_denom": len(by_task),
+            "success_any": len(success_tasks),
+            "observed_on_scored_tasks": len(success_tasks) / len(by_task) if by_task else None,
+            "lower_bound_all_tasks": len(success_tasks) / total_tasks,
+        },
+        "per_k_complete_prefix": per_k,
+        "mean_score_all_scored_attempts": sum(scores) / len(scores) if scores else None,
+        "completed_attempts_without_grades": [
+            {"task_id": task_id, "attempt": attempt}
+            for task_id, attempt in sorted(completed_without_grades)
+        ],
+        "n_scored_attempts_per_task_distribution": dict(
+            sorted(collections.Counter(len(attempts) for attempts in by_task.values()).items())
+        ),
+        "score_bins": dict(score_bins),
+        "failure_analysis": {
+            "method": (
+                "Heuristic parsing of verifier grade_rationale for current scored attempts. "
+                "Trajectory samples were used to validate the major categories; exact category labels are directional."
+            ),
+            "verifier_total": verifier_total_count,
+            "verifier_failed": verifier_failed_count,
+            "verifier_failure_categories": [
+                {
+                    "category": category,
+                    "label": FAILURE_CATEGORY_LABELS.get(category, category),
+                    "count": count,
+                    "share_of_failed_verifiers": count / verifier_failed_count if verifier_failed_count else None,
+                    "example": verifier_failure_examples.get(category),
+                }
+                for category, count in verifier_failure_categories.most_common()
+            ],
+            "attempt_primary_categories": [
+                {
+                    "category": category,
+                    "label": "Pass" if category == "pass" else FAILURE_CATEGORY_LABELS.get(category, category),
+                    "attempts": count,
+                    "mean_score": (
+                        sum(attempt_primary_scores[category]) / len(attempt_primary_scores[category])
+                        if attempt_primary_scores[category]
+                        else None
+                    ),
+                }
+                for category, count in attempt_primary_categories.most_common()
+            ],
+            "trajectory_sample_findings": [
+                {
+                    "task_id": "task_00b30f56f39a4a9891d9503443bafb27",
+                    "attempt": "attempt1",
+                    "score": 0.4,
+                    "finding": "CNS valuation path mostly worked, but failed exact numeric checks by 0.1-0.2mm and mean rounding.",
+                },
+                {
+                    "task_id": "task_0de09be0daf242208f7a60ee83bf8717",
+                    "attempt": "attempt2",
+                    "score": 0.42857142857142855,
+                    "finding": "Same task has passing attempts, but this rollout chose the wrong filtered EV/EBITDA and made $48.35 the primary answer instead of $51.03.",
+                },
+                {
+                    "task_id": "task_a757e127fe3a4b148dadeb34ef3540f7",
+                    "attempt": "attempt5",
+                    "score": 0.14285714285714285,
+                    "finding": "Elastic LBO workbook was modified and answered, but assumption propagation produced systematically wrong exit metrics.",
+                },
+                {
+                    "task_id": "task_db355b58e80749a1879a9d79681d05cc",
+                    "attempt": "attempt2",
+                    "score": 0.0,
+                    "finding": "Agent read the spreadsheet and hand-computed CAGRs, but used the wrong financial calculation basis.",
+                },
+            ],
+            "rl_data_recommendation": [
+                "Prioritize finance workbook mutation, recalculation, and exact output-cell extraction over generic retrieval tasks.",
+                "Create same-task winner/loser preference pairs from pass vs partial rollouts.",
+                "Add numeric-distance, formula-health, artifact-state, and primary-answer-selection reward signals.",
+                "Keep retrieval worlds, but use them mainly as support for spreadsheet and document-output workflows.",
+            ],
+        },
+        "task_scores": {
+            task_id: {str(attempt): score for attempt, score in sorted(attempts.items())}
+            for task_id, attempts in sorted(by_task.items())
+        },
+        "price_value_verifier_scores": {
+            task_id: {
+                str(attempt): {"score": values["score"], "n": values["n"]}
+                for attempt, values in sorted(attempts.items())
+            }
+            for task_id, attempts in sorted(price_by_task.items())
+        },
+    }
+
+
+def bar(label: str, value: int, max_value: int, klass: str = "") -> str:
+    width = (value / max_value * 100) if max_value else 0
+    class_attr = f' class="{klass}"' if klass else ""
+    return f'<div class="bar"><span>{html.escape(label)}</span><b{class_attr} style="width:{width:.1f}%"></b><em>{value}</em></div>'
+
+
+def render_html(report: dict[str, Any], project_dir: str, bucket: str) -> str:
+    attempts = {int(k): v for k, v in report["attempt_counts"].items()}
+    successes = {int(k): v for k, v in report["success_by_attempt"].items()}
+    max_attempt_count = max(attempts.values() or [1])
+    attempt_bars = "\n".join(
+        bar(f"attempt{i}", attempts.get(i, 0), max_attempt_count) for i in sorted(attempts)
+    )
+    attempt_rows = "\n".join(
+        "<tr>"
+        f"<td>attempt{i}</td><td>{attempts.get(i, 0)}</td><td>{successes.get(i, 0)}</td>"
+        f"<td>{(successes.get(i, 0) / attempts.get(i, 1) * 100 if attempts.get(i, 0) else 0):.2f}%</td>"
+        "</tr>"
+        for i in sorted(attempts)
+    )
+
+    dist = {int(k): v for k, v in report["n_scored_attempts_per_task_distribution"].items()}
+    max_dist = max(dist.values() or [1])
+    dist_bars = "\n".join(bar(f"{k} attempts", v, max_dist, "green") for k, v in sorted(dist.items()))
+
+    score_order = ["0", "0-<0.5", "0.5-<0.8", "0.8-<1", "1.0"]
+    bins = report["score_bins"]
+    max_bin = max((bins.get(k, 0) for k in score_order), default=1)
+    bin_bars = "\n".join(
+        bar(
+            k,
+            bins.get(k, 0),
+            max_bin,
+            "green" if k == "1.0" else "red" if k == "0" else "amber",
+        )
+        for k in score_order
+    )
+
+    prefix_rows = "\n".join(
+        "<tr>"
+        f"<td>{row['k']}</td><td>{row['n_tasks_with_1_to_k']}</td><td>{row['successes']}</td>"
+        f"<td>{pct(row['pass_at_k'])}</td><td>{pct(row['lower_bound_all_tasks'])}</td>"
+        f"<td>{num(row['mean_best_score'])}</td>"
+        "</tr>"
+        for row in report["per_k_complete_prefix"]
+    )
+    passk_rows = [
+        row for row in report["per_k_complete_prefix"]
+        if row["pass_at_k"] is not None and 1 <= int(row["k"]) <= 8
+    ]
+    passk_by_k = {int(row["k"]): row for row in passk_rows}
+    prediction_rows: list[dict[str, Any]] = []
+    prediction_note = ""
+    if all(k in passk_by_k for k in range(1, 9)):
+        observed = [(k, float(passk_by_k[k]["successes"])) for k in range(1, 9)]
+        total_tasks = int(report["total_tasks"])
+        s1 = observed[0][1]
+        max_seen = max(successes for _, successes in observed)
+        best_fit: tuple[float, float, float] | None = None
+        # Saturating exponential: S_k = L - (L - S_1) * exp(-b * (k - 1)).
+        # Grid search is stable enough here and avoids adding scipy as a report dependency.
+        for l_i in range(int(math.ceil(max_seen * 100)), total_tasks * 100 + 1):
+            asymptote = l_i / 100
+            if asymptote <= s1:
+                continue
+            for b_i in range(1, 1001):
+                decay = b_i / 1000
+                sse = 0.0
+                for k, actual in observed:
+                    predicted = asymptote - (asymptote - s1) * math.exp(-decay * (k - 1))
+                    sse += (predicted - actual) ** 2
+                if best_fit is None or sse < best_fit[0]:
+                    best_fit = (sse, asymptote, decay)
+        asymptote = best_fit[1] if best_fit else float(total_tasks)
+        decay = best_fit[2] if best_fit else 0.0
+        for k in (9, 10):
+            predicted_successes = min(
+                float(total_tasks),
+                asymptote - (asymptote - s1) * math.exp(-decay * (k - 1)),
+            )
+            prediction_rows.append(
+                {
+                    "k": k,
+                    "predicted_successes": predicted_successes,
+                    "pass_at_k": predicted_successes / total_tasks if total_tasks else None,
+                }
+            )
+        prediction_note = (
+            "预测方法：对 pass@1-8 的累计成功 task 数拟合饱和指数曲线 "
+            f"S_k = L - (L - S_1) * exp(-b*(k-1))，估计上限 L={asymptote:.1f} tasks，"
+            f"收敛速度 b={decay:.3f}。预测段仅用于趋势参考。"
+        )
+    chart_w, chart_h = 760, 300
+    left, right, top, bottom = 54, 22, 18, 42
+    plot_w = chart_w - left - right
+    plot_h = chart_h - top - bottom
+    max_rate = max(
+        [
+            0.4,
+            *[float(row["pass_at_k"]) for row in passk_rows],
+            *[float(row["pass_at_k"]) for row in prediction_rows if row["pass_at_k"] is not None],
+        ],
+        default=0.4,
+    )
+    y_max = min(1.0, max(0.4, ((int(max_rate * 10 + 0.999) or 1) / 10)))
+
+    def chart_x(k: int) -> float:
+        return left + ((k - 1) / 9) * plot_w
+
+    def chart_y(rate: float) -> float:
+        return top + (1 - rate / y_max) * plot_h
+
+    polyline_points = " ".join(
+        f"{chart_x(int(row['k'])):.1f},{chart_y(float(row['pass_at_k'])):.1f}"
+        for row in passk_rows
+    )
+    projected_points = " ".join(
+        [
+            f"{chart_x(8):.1f},{chart_y(float(passk_by_k[8]['pass_at_k'])):.1f}"
+            if 8 in passk_by_k
+            else "",
+            *[
+                f"{chart_x(int(row['k'])):.1f},{chart_y(float(row['pass_at_k'])):.1f}"
+                for row in prediction_rows
+                if row["pass_at_k"] is not None
+            ],
+        ]
+    ).strip()
+    y_ticks = [0, y_max / 4, y_max / 2, y_max * 3 / 4, y_max]
+    y_grid = "\n".join(
+        f'<line x1="{left}" y1="{chart_y(t):.1f}" x2="{chart_w - right}" y2="{chart_y(t):.1f}" class="gridline"/>'
+        f'<text x="{left - 10}" y="{chart_y(t) + 4:.1f}" class="axislabel" text-anchor="end">{t * 100:.0f}%</text>'
+        for t in y_ticks
+    )
+    x_ticks = "\n".join(
+        f'<line x1="{chart_x(k):.1f}" y1="{chart_h - bottom}" x2="{chart_x(k):.1f}" y2="{chart_h - bottom + 5}" class="tick"/>'
+        f'<text x="{chart_x(k):.1f}" y="{chart_h - 16}" class="axislabel" text-anchor="middle">pass@{k}</text>'
+        for k in range(1, 11)
+    )
+    passk_points = "\n".join(
+        f'<g><circle cx="{chart_x(int(row["k"])):.1f}" cy="{chart_y(float(row["pass_at_k"])):.1f}" r="4.5" class="point"/>'
+        f'<text x="{chart_x(int(row["k"])):.1f}" y="{chart_y(float(row["pass_at_k"])) - 10:.1f}" class="pointlabel" text-anchor="middle">{pct(float(row["pass_at_k"]))}</text></g>'
+        for row in passk_rows
+    )
+    predicted_points = "\n".join(
+        f'<g><circle cx="{chart_x(int(row["k"])):.1f}" cy="{chart_y(float(row["pass_at_k"])):.1f}" r="4.5" class="predpoint"/>'
+        f'<text x="{chart_x(int(row["k"])):.1f}" y="{chart_y(float(row["pass_at_k"])) - 10:.1f}" class="pointlabel" text-anchor="middle">{pct(float(row["pass_at_k"]))}</text></g>'
+        for row in prediction_rows
+        if row["pass_at_k"] is not None
+    )
+    passk_chart = f"""
+<svg class="linechart" viewBox="0 0 {chart_w} {chart_h}" role="img" aria-label="pass@1 到 pass@8 通过率折线图">
+  {y_grid}
+  <line x1="{left}" y1="{top}" x2="{left}" y2="{chart_h - bottom}" class="axis"/>
+  <line x1="{left}" y1="{chart_h - bottom}" x2="{chart_w - right}" y2="{chart_h - bottom}" class="axis"/>
+  {x_ticks}
+  <polyline points="{polyline_points}" class="passline"/>
+  <polyline points="{projected_points}" class="predline"/>
+  {passk_points}
+  {predicted_points}
+</svg>
+"""
+
+    task_scores: dict[str, dict[str, float]] = report.get("task_scores", {})
+    heatmap_attempts = list(range(1, max([8, *[int(a) for scores in task_scores.values() for a in scores.keys()]], default=8) + 1))
+
+    def score_class(score: float | None) -> str:
+        if score is None:
+            return "missing"
+        if score >= 1.0:
+            return "pass"
+        if score >= 0.8:
+            return "near"
+        if score >= 0.5:
+            return "mid"
+        if score > 0:
+            return "low"
+        return "zero"
+
+    heatmap_head = "".join(f"<th>a{i}</th>" for i in heatmap_attempts)
+
+    def render_score_heatmap_rows(score_map: dict[str, dict[str, float]]) -> str:
+        return "\n".join(
+            "<tr>"
+            f"<td class=\"task\"><code>{html.escape(task_id)}</code></td>"
+            + "".join(
+                (
+                    f"<td class=\"cell {score_class(scores.get(str(i)))}\" "
+                    f"title=\"{html.escape(task_id)} attempt{i}: "
+                    f"{'missing' if scores.get(str(i)) is None else num(scores.get(str(i)))}\">"
+                    f"{'' if scores.get(str(i)) is None else num(scores.get(str(i)))}"
+                    "</td>"
+                )
+                for i in heatmap_attempts
+            )
+            + "</tr>"
+            for task_id, scores in sorted(score_map.items())
+        )
+
+    heatmap_rows = render_score_heatmap_rows(task_scores)
+
+    pass1 = report["pass_at_1_attempt1_only"]
+    any_pass = report["current_any_attempt_pass_rate"]
+    per_k_by_k = {row["k"]: row for row in report["per_k_complete_prefix"]}
+    pass5 = per_k_by_k.get(5)
+    pass8 = per_k_by_k.get(8)
+    json_uri = f"gs://{bucket}/{project_dir}/state/stage-report-passk-current.json"
+    missing_grade_count = len(report.get("completed_attempts_without_grades", []))
+    failure_analysis = report.get("failure_analysis", {})
+    verifier_failed = int(failure_analysis.get("verifier_failed", 0) or 0)
+    verifier_total = int(failure_analysis.get("verifier_total", 0) or 0)
+    failure_category_rows = "\n".join(
+        "<tr>"
+        f"<td>{html.escape(row.get('label', row.get('category', '')))}</td>"
+        f"<td>{row.get('count', 0)}</td>"
+        f"<td>{pct(row.get('share_of_failed_verifiers'))}</td>"
+        f"<td><code>{html.escape((row.get('example') or {}).get('task_id', ''))}</code> "
+        f"{html.escape(str((row.get('example') or {}).get('attempt', '')))}</td>"
+        f"<td>{html.escape((row.get('example') or {}).get('example', ''))}</td>"
+        "</tr>"
+        for row in failure_analysis.get("verifier_failure_categories", [])
+    )
+    attempt_primary_rows = "\n".join(
+        "<tr>"
+        f"<td>{html.escape(row.get('label', row.get('category', '')))}</td>"
+        f"<td>{row.get('attempts', 0)}</td>"
+        f"<td>{num(row.get('mean_score'))}</td>"
+        "</tr>"
+        for row in failure_analysis.get("attempt_primary_categories", [])
+    )
+    sample_finding_rows = "\n".join(
+        "<tr>"
+        f"<td><code>{html.escape(row.get('task_id', ''))}</code></td>"
+        f"<td>{html.escape(str(row.get('attempt', '')))}</td>"
+        f"<td>{num(row.get('score'))}</td>"
+        f"<td>{html.escape(row.get('finding', ''))}</td>"
+        "</tr>"
+        for row in failure_analysis.get("trajectory_sample_findings", [])
+    )
+    rl_recommendations = "\n".join(
+        f"<li>{html.escape(item)}</li>"
+        for item in failure_analysis.get("rl_data_recommendation", [])
+    )
+
+    return f"""<!doctype html>
+<html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Seed Pro IB 当前阶段报告</title>
+<style>
+body{{margin:0;background:#f6f7f9;color:#1f2933;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.5}}
+main{{max-width:1180px;margin:auto;padding:28px 24px 48px}}h1{{margin:0 0 8px;font-size:30px;letter-spacing:0}}h2{{font-size:18px;margin:0 0 12px}}
+.meta{{color:#697586;font-size:14px}}.grid{{display:grid;gap:16px}}.metrics{{grid-template-columns:repeat(5,minmax(0,1fr));margin:20px 0}}.two{{grid-template-columns:1fr 1fr;margin-top:16px}}
+.panel{{background:white;border:1px solid #d9dee7;border-radius:8px;padding:18px;box-shadow:0 1px 2px rgba(16,24,40,.06)}}.label{{font-size:13px;color:#697586;margin-bottom:8px}}.value{{font-size:32px;font-weight:700;line-height:1}}
+.sub,.note{{font-size:13px;color:#697586;margin-top:8px}}.ok{{color:#16865a}}.info{{color:#2866c7}}table{{width:100%;border-collapse:collapse;font-size:14px}}th,td{{padding:9px 8px;border-bottom:1px solid #d9dee7;text-align:left}}th{{font-size:12px;color:#697586;text-transform:uppercase}}.compact td{{vertical-align:top;font-size:13px}}.compact td:last-child{{color:#4b5565}}ul{{margin:8px 0 0;padding-left:20px}}li{{margin:5px 0}}
+.bar{{display:grid;grid-template-columns:92px 1fr 52px;gap:10px;align-items:center;margin:9px 0;font-size:14px}}.bar b{{display:block;height:12px;border-radius:4px;background:#2866c7}}.bar b.green{{background:#16865a}}.bar b.amber{{background:#a66500}}.bar b.red{{background:#b42318}}
+.linechart{{width:100%;height:auto;display:block}}.linechart .gridline{{stroke:#e6ebf2;stroke-width:1}}.linechart .axis,.linechart .tick{{stroke:#98a2b3;stroke-width:1.2}}.linechart .passline{{fill:none;stroke:#2866c7;stroke-width:3;stroke-linecap:round;stroke-linejoin:round}}.linechart .predline{{fill:none;stroke:#a66500;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:7 6}}.linechart .point{{fill:#16865a;stroke:white;stroke-width:2}}.linechart .predpoint{{fill:#a66500;stroke:white;stroke-width:2}}.linechart .axislabel{{fill:#697586;font-size:12px}}.linechart .pointlabel{{fill:#1f2933;font-size:12px;font-weight:700}}
+.heatwrap{{overflow:auto;max-height:720px;border:1px solid #d9dee7;border-radius:8px}}.heatmap{{border-collapse:separate;border-spacing:0;font-size:12px;min-width:760px}}.heatmap th{{position:sticky;top:0;background:#f8fafc;z-index:2}}.heatmap .task{{position:sticky;left:0;background:#fff;z-index:1;min-width:260px}}.heatmap th,.heatmap td{{border-bottom:1px solid #e6ebf2;border-right:1px solid #eef2f7;padding:6px 7px;text-align:center;white-space:nowrap}}.heatmap .cell{{font-variant-numeric:tabular-nums;min-width:54px}}.heatmap .missing{{background:#f2f4f7;color:#98a2b3}}.heatmap .zero{{background:#f8d7da;color:#7a271a}}.heatmap .low{{background:#fff1c2;color:#7a4b00}}.heatmap .mid{{background:#cfe8ff;color:#164c8a}}.heatmap .near{{background:#b7e4c7;color:#0b5d3b}}.heatmap .pass{{background:#16865a;color:white;font-weight:700}}.legend{{display:flex;flex-wrap:wrap;gap:10px;margin:10px 0 0;font-size:12px;color:#697586}}.legend span{{display:inline-flex;align-items:center;gap:5px}}.swatch{{width:14px;height:14px;border-radius:3px;display:inline-block;border:1px solid #d9dee7}}.heat-missing{{background:#f2f4f7}}.heat-zero{{background:#f8d7da}}.heat-low{{background:#fff1c2}}.heat-mid{{background:#cfe8ff}}.heat-near{{background:#b7e4c7}}.heat-pass{{background:#16865a}}
+code{{background:#eef2f7;padding:2px 5px;border-radius:4px;font-size:12px}}.callout{{border-left:4px solid #a66500;background:#fff8ec;padding:12px 14px;border-radius:6px;color:#614000;font-size:14px}}
+@media(max-width:900px){{.metrics,.two{{grid-template-columns:1fr 1fr}}}}@media(max-width:620px){{main{{padding:20px 14px}}.metrics,.two{{grid-template-columns:1fr}}}}
+</style></head><body><main>
+<h1>APEX Agents IB 当前阶段报告：pass@1 / pass@k</h1>
+<p class="meta">项目：<code>{html.escape(project_dir)}</code></p>
+<p class="meta">生成时间：{html.escape(report["generated_at"])}</p>
+<section class="grid metrics">
+<div class="panel"><div class="label">pass@1 观测值</div><div class="value ok">{pct(pass1["observed_on_attempt1_graded_tasks"])}</div><div class="sub">{pass1["successes"]} / {pass1["tasks_with_attempt1_grade"]} 个 attempt1 已打分 task 成功</div></div>
+<div class="panel"><div class="label">pass@5</div><div class="value ok">{pct(pass5["pass_at_k"] if pass5 else None)}</div><div class="sub">{pass5["successes"] if pass5 else 0} / {pass5["n_tasks_with_1_to_k"] if pass5 else 0} 个完整前缀 task 成功</div></div>
+<div class="panel"><div class="label">pass@8</div><div class="value ok">{pct(pass8["pass_at_k"] if pass8 else None)}</div><div class="sub">{pass8["successes"] if pass8 else 0} / {pass8["n_tasks_with_1_to_k"] if pass8 else 0} 个完整前缀 task 成功</div></div>
+<div class="panel"><div class="label">已计入 attempts</div><div class="value info">{report["scored_attempts"]}</div><div class="sub">覆盖 {report["scored_tasks"]} / {report["total_tasks"]} 个 task；无 grades 记 0：{missing_grade_count}</div></div>
+<div class="panel"><div class="label">平均分</div><div class="value">{num(report["mean_score_all_scored_attempts"])}</div><div class="sub">所有已打分 attempts final_score 均值</div></div>
+</section>
+<section class="panel"><h2>当前结论</h2><div class="callout">这是当前阶段报告。Prefix pass@k 要求同一 task 具备 attempt1..k 的完成结果；完整执行但没有 grades.json 的 attempt 按 0 分计入。</div></section>
+<section class="panel" style="margin-top:16px"><h2>pass@1 到 pass@10 通过率趋势</h2>{passk_chart}<p class="note">{html.escape(prediction_note)}</p></section>
+<section class="grid two"><div class="panel"><h2>Attempt 覆盖</h2>{attempt_bars}<table><thead><tr><th>attempt</th><th>已计入</th><th>成功 attempt</th><th>attempt 成功率</th></tr></thead><tbody>{attempt_rows}</tbody></table></div><div class="panel"><h2>每个 task 已计入 attempts 数</h2>{dist_bars}</div></section>
+<section class="grid two"><div class="panel"><h2>Prefix pass@k</h2><table><thead><tr><th>k</th><th>完整前缀 task</th><th>成功 task</th><th>pass@k</th><th>全量下界</th><th>best score 均值</th></tr></thead><tbody>{prefix_rows}</tbody></table></div><div class="panel"><h2>分数分布</h2>{bin_bars}<p class="note">成功阈值：<code>final_score &gt;= 1.0</code>。</p></div></section>
+<section class="panel" style="margin-top:16px"><h2>RL 数据诊断：Verifier 丢分归因</h2><p class="note">当前 scored attempts 的 verifier checks：{verifier_failed} / {verifier_total} failed。分类来自 <code>grades.json</code> 的 judge rationale 规则解析，类别用于定位 RL 数据方向，不作为精确人工标签。</p><table class="compact"><thead><tr><th>failure category</th><th>failed verifiers</th><th>占 failed verifier</th><th>example</th><th>evidence snippet</th></tr></thead><tbody>{failure_category_rows}</tbody></table></section>
+<section class="grid two"><div class="panel"><h2>Attempt 主失败类型</h2><table><thead><tr><th>primary category</th><th>attempts</th><th>mean score</th></tr></thead><tbody>{attempt_primary_rows}</tbody></table></div><div class="panel"><h2>RL 数据建议</h2><ul>{rl_recommendations}</ul><p class="note">结论：当前 IB benchmark 主要瓶颈不是泛化检索，而是 finance workbook mutation、recalculation、exact numeric extraction、artifact/final answer 对齐。</p></div></section>
+<section class="panel" style="margin-top:16px"><h2>Trajectory 样本验证</h2><table class="compact"><thead><tr><th>task</th><th>attempt</th><th>score</th><th>finding</th></tr></thead><tbody>{sample_finding_rows}</tbody></table></section>
+<section class="panel" style="margin-top:16px"><h2>Task × Attempt Score 热力图</h2><div class="heatwrap"><table class="heatmap"><thead><tr><th class="task">task</th>{heatmap_head}</tr></thead><tbody>{heatmap_rows}</tbody></table></div><div class="legend"><span><i class="swatch heat-missing"></i>missing</span><span><i class="swatch heat-zero"></i>0</span><span><i class="swatch heat-low"></i>0-0.5</span><span><i class="swatch heat-mid"></i>0.5-0.8</span><span><i class="swatch heat-near"></i>0.8-1</span><span><i class="swatch heat-pass"></i>1.0 pass</span></div></section>
+<section class="panel" style="margin-top:16px"><h2>报告来源</h2><p class="meta">JSON：<code>{html.escape(json_uri)}</code></p></section>
+</main></body></html>"""
+
+
+def upload(path: Path, uri: str) -> None:
+    subprocess.run(["gsutil", "cp", str(path), uri], check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate staged pass@k report from GCS result artifacts")
+    parser.add_argument("--bucket", default="sotalab-archipelago-eval")
+    parser.add_argument("--project-dir", required=True)
+    parser.add_argument("--total-tasks", type=int, default=160)
+    parser.add_argument("--output-html", default=None)
+    parser.add_argument("--output-json", default=None)
+    parser.add_argument("--upload", action="store_true")
+    parser.add_argument("--jobs", type=int, default=64)
+    args = parser.parse_args()
+
+    storage_mod = require_storage()
+    client = storage_mod.Client()
+    bucket = client.bucket(args.bucket)
+    blob_names = list_result_blobs(client, args.bucket, args.project_dir)
+    print(f"result_artifacts={len(blob_names)}")
+
+    artifacts: dict[tuple[str, int], set[str]] = collections.defaultdict(set)
+    grade_blob_names: list[str] = []
+    for name in blob_names:
+        match = ARTIFACT_RE.search("/" + name)
+        if not match:
+            continue
+        key = (match.group(1), int(match.group(2)))
+        artifact = match.group(3)
+        artifacts[key].add(artifact)
+        if artifact == "grades.json":
+            grade_blob_names.append(name)
+    print(f"grades={len(grade_blob_names)}")
+
+    rows: list[tuple[str, int, float, float | None, int, dict[str, int], int, int, dict[str, str]]] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
+        for row in executor.map(lambda name: read_grade(bucket, name), grade_blob_names):
+            if row is not None:
+                rows.append(row)
+    grade_keys = {(task_id, attempt) for task_id, attempt, *_ in rows}
+    completed_without_grades = [
+        key
+        for key, names in artifacts.items()
+        if {"status.tsv", "trajectory.json"} <= names and key not in grade_keys
+    ]
+    for task_id, attempt in completed_without_grades:
+        rows.append((task_id, attempt, 0.0, None, 0, {}, 0, 0, {}))
+    print(f"completed_without_grades={len(completed_without_grades)}")
+
+    report = aggregate(rows, args.total_tasks, completed_without_grades)
+    report["project_dir"] = args.project_dir
+    report["bucket"] = args.bucket
+
+    output_json = Path(args.output_json or "/tmp/seed-pro-ib-pass8-stage-report-current.json")
+    output_html = Path(
+        args.output_html
+        or "/Users/lumin/sotalab/reports/seed-pro-ib-pass8-stage-report-current.html"
+    )
+    output_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    output_html.parent.mkdir(parents=True, exist_ok=True)
+    output_html.write_text(render_html(report, args.project_dir, args.bucket))
+
+    if args.upload:
+        upload(output_json, f"gs://{args.bucket}/{args.project_dir}/state/stage-report-passk-current.json")
+        upload(output_html, f"gs://{args.bucket}/{args.project_dir}/state/stage-report-passk-current.html")
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    print(f"html={output_html}")
+    print(f"json={output_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/launch_dynamic_workers.py
+++ b/scripts/launch_dynamic_workers.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Scale dynamic GCS-queue workers on GCE.
+
+This script packages the current archipelago checkout, uploads it to GCS, then
+creates enough worker VMs to reach --target-running. It is intentionally
+idempotent for expansion: existing active VMs with the same prefix are counted
+first, and --max-running is enforced before any VM is created.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+ACTIVE_STATUSES = {"PROVISIONING", "STAGING", "RUNNING", "REPAIRING"}
+DEFAULT_ENV_IMAGE = (
+    "asia-east1-docker.pkg.dev/sotalab-prod/docker-repo/"
+    "sotalab-apex-archipelago-environment-prod"
+)
+
+
+def run(cmd: list[str], *, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(cmd), flush=True)
+    return subprocess.run(
+        cmd,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def default_project_dir(eval_project: str | None, project_dir: str | None) -> str:
+    if project_dir:
+        return project_dir
+    if not eval_project:
+        raise SystemExit("Either --project-dir or --eval-project is required")
+    return f"eval-projects/{eval_project}"
+
+
+def list_instances(project: str, prefix: str) -> list[dict[str, Any]]:
+    proc = run(
+        [
+            "gcloud",
+            "compute",
+            "instances",
+            "list",
+            f"--project={project}",
+            f"--filter=name~^{re.escape(prefix)}-",
+            "--format=json(name,zone,status)",
+        ],
+        capture=True,
+    )
+    return json.loads(proc.stdout or "[]")
+
+
+def zone_name(zone_url: str) -> str:
+    return zone_url.rsplit("/", 1)[-1]
+
+
+def active_instances(instances: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [item for item in instances if item.get("status") in ACTIVE_STATUSES]
+
+
+def next_worker_names(prefix: str, existing_names: set[str], count: int) -> list[str]:
+    names: list[str] = []
+    index = 1
+    while len(names) < count:
+        name = f"{prefix}-{index:03d}"
+        if name not in existing_names:
+            names.append(name)
+        index += 1
+    return names
+
+
+def upload_bundle(bucket: str, project_dir: str, bundle_uri: str | None) -> str:
+    if bundle_uri:
+        return bundle_uri
+
+    root = repo_root()
+    parent = root.parent
+    target_uri = f"gs://{bucket}/{project_dir}/setup/archipelago.tgz"
+    with tempfile.TemporaryDirectory() as tmp:
+        archive = Path(tmp) / "archipelago.tgz"
+        excludes = [
+            "--exclude=archipelago/.git",
+            "--exclude=archipelago/.venv",
+            "--exclude=archipelago/agents/.venv",
+            "--exclude=archipelago/grading/.venv",
+            "--exclude=archipelago/environment/.venv",
+            "--exclude=archipelago/.apex_local",
+            "--exclude=archipelago/apex-samples.zip",
+            "--exclude=archipelago/examples/hugging_face_task/output",
+            "--exclude=archipelago/agents/output",
+            "--exclude=archipelago/grading/output",
+            "--exclude=archipelago/environment/output",
+            "--exclude=__pycache__",
+            "--exclude=.pytest_cache",
+            "--exclude=node_modules",
+        ]
+        run(["env", "COPYFILE_DISABLE=1", "tar", *excludes, "-czf", str(archive), "-C", str(parent), root.name])
+        run(["gsutil", "cp", str(archive), target_uri])
+    return target_uri
+
+
+def upload_task_ids(bucket: str, project_dir: str, task_ids_file: str | None, task_ids_uri: str | None) -> str:
+    if task_ids_file:
+        target_uri = task_ids_uri or f"gs://{bucket}/{project_dir}/state/task_ids.json"
+        run(["gsutil", "cp", task_ids_file, target_uri])
+        return target_uri
+    if task_ids_uri:
+        return task_ids_uri
+    return f"gs://{bucket}/{project_dir}/state/task_ids.json"
+
+
+def create_instance(
+    *,
+    project: str,
+    zone: str,
+    name: str,
+    machine_type: str,
+    boot_disk_size: str,
+    image_family: str,
+    image_project: str,
+    service_account: str | None,
+    metadata: dict[str, str],
+) -> None:
+    metadata_arg = ",".join(f"{key}={value}" for key, value in metadata.items())
+    cmd = [
+        "gcloud",
+        "compute",
+        "instances",
+        "create",
+        name,
+        f"--project={project}",
+        f"--zone={zone}",
+        f"--machine-type={machine_type}",
+        f"--boot-disk-size={boot_disk_size}",
+        f"--image-family={image_family}",
+        f"--image-project={image_project}",
+        "--scopes=https://www.googleapis.com/auth/cloud-platform",
+        f"--metadata-from-file=startup-script={repo_root() / 'scripts' / 'setup_worker.sh'}",
+        f"--metadata={metadata_arg}",
+        "--quiet",
+    ]
+    if service_account:
+        cmd.append(f"--service-account={service_account}")
+    run(cmd)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Scale dynamic archipelago GCE workers")
+    parser.add_argument("--project", default="sotalab-prod")
+    parser.add_argument("--eval-project", default=None)
+    parser.add_argument("--project-dir", default=None)
+    parser.add_argument("--bucket", default="sotalab-archipelago-eval")
+    parser.add_argument("--worker-prefix", default="archipelago-eval-auto")
+    parser.add_argument("--target-running", type=int, required=True)
+    parser.add_argument("--max-running", type=int, default=None)
+    parser.add_argument("--zones", default="us-central1-a,us-west1-a,asia-east1-b")
+    parser.add_argument("--machine-type", default="e2-standard-4")
+    parser.add_argument("--boot-disk-size", default="150GB")
+    parser.add_argument("--image-family", default="debian-12")
+    parser.add_argument("--image-project", default="debian-cloud")
+    parser.add_argument("--service-account", default=None)
+    parser.add_argument("--queue-name", default="pass5")
+    parser.add_argument("--attempt-start", type=int, default=1)
+    parser.add_argument("--attempt-end", type=int, default=5)
+    parser.add_argument("--model", default="doubao-seed-2-0-pro-260215")
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--max-steps", type=int, default=200)
+    parser.add_argument("--max-consecutive-failures", type=int, default=2)
+    parser.add_argument("--task-ids-file", default=None)
+    parser.add_argument("--task-ids-gcs-uri", default=None)
+    parser.add_argument("--bundle-gcs-uri", default=None)
+    parser.add_argument("--env-image", default=DEFAULT_ENV_IMAGE)
+    parser.add_argument("--env-image-tag", default="latest")
+    parser.add_argument("--new-api-secret-name", default="NEW_API_TOKEN-staging")
+    parser.add_argument("--hf-token-secret-name", default="HF_TOKEN")
+    parser.add_argument("--new-api-base", default="https://new-api-staging.sotalab.ai/v1")
+    args = parser.parse_args()
+
+    if args.target_running < 0:
+        raise SystemExit("--target-running must be >= 0")
+    max_running = args.max_running if args.max_running is not None else args.target_running
+    if args.target_running > max_running:
+        raise SystemExit("--target-running cannot exceed --max-running")
+
+    project_dir = default_project_dir(args.eval_project, args.project_dir)
+    zones = [zone.strip() for zone in args.zones.split(",") if zone.strip()]
+    if not zones:
+        raise SystemExit("--zones must contain at least one zone")
+
+    instances = list_instances(args.project, args.worker_prefix)
+    active = active_instances(instances)
+    print(f"[scale] active={len(active)} target={args.target_running} max={max_running}")
+    if len(active) >= args.target_running:
+        print("[scale] nothing to create")
+        return 0
+    to_create = args.target_running - len(active)
+    if len(active) + to_create > max_running:
+        raise SystemExit("refusing to exceed --max-running")
+
+    bundle_uri = upload_bundle(args.bucket, project_dir, args.bundle_gcs_uri)
+    task_ids_uri = upload_task_ids(
+        args.bucket,
+        project_dir,
+        args.task_ids_file,
+        args.task_ids_gcs_uri,
+    )
+    run(["gsutil", "cp", "/dev/null", f"gs://{args.bucket}/{project_dir}/state/.keep"], check=False)
+    run(["gsutil", "cp", "/dev/null", f"gs://{args.bucket}/{project_dir}/results/.keep"], check=False)
+
+    existing_names = {item["name"] for item in instances}
+    names = next_worker_names(args.worker_prefix, existing_names, to_create)
+    metadata = {
+        "ARCHIPELAGO_TGZ_GCS_URI": bundle_uri,
+        "EVAL_PROJECT_DIR": project_dir,
+        "EVAL_BUCKET": args.bucket,
+        "RUN_DYNAMIC_QUEUE": "1",
+        "QUEUE_NAME": args.queue_name,
+        "ATTEMPT_START": str(args.attempt_start),
+        "ATTEMPT_END": str(args.attempt_end),
+        "EVAL_MODEL": args.model,
+        "TEMPERATURE": str(args.temperature),
+        "MAX_STEPS": str(args.max_steps),
+        "MAX_CONSECUTIVE_FAILURES": str(args.max_consecutive_failures),
+        "TASK_IDS_GCS_URI": task_ids_uri,
+        "JOBS_FILE": "/opt/archipelago/state/task_ids.json",
+        "ENV_IMAGE": args.env_image,
+        "ENV_IMAGE_TAG": args.env_image_tag,
+        "NEW_API_SECRET_NAME": args.new_api_secret_name,
+        "HF_TOKEN_SECRET_NAME": args.hf_token_secret_name,
+        "NEW_API_BASE": args.new_api_base,
+    }
+
+    created: list[tuple[str, str]] = []
+    for offset, name in enumerate(names):
+        zone = zones[(len(active) + offset) % len(zones)]
+        print(f"[scale] creating {name} in {zone}")
+        create_instance(
+            project=args.project,
+            zone=zone,
+            name=name,
+            machine_type=args.machine_type,
+            boot_disk_size=args.boot_disk_size,
+            image_family=args.image_family,
+            image_project=args.image_project,
+            service_account=args.service_account,
+            metadata=metadata,
+        )
+        created.append((name, zone))
+        time.sleep(2)
+
+    print("[scale] created:")
+    for name, zone in created:
+        print(f"  {name}\t{zone}")
+    print("[scale] check health with:")
+    print(
+        "  python scripts/worker_healthcheck.py "
+        f"--project {args.project} --worker-prefix {args.worker_prefix}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local_scheduler.py
+++ b/scripts/local_scheduler.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Local (Mac) scheduler for the archipelago GCS-backed eval.
+
+Subcommands:
+  publish    Sample tasks + write jobs/task ids to local state and GCS
+  status     Print current progress from GCS results/state
+  aggregate  Download all grades.json from GCS, compute pass@1/pass@3/mean score
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROJECT_DIR_DEFAULT = "eval-projects/seed-pro-pass3-20260616"
+BUCKET_DEFAULT = "sotalab-archipelago-eval"
+GCP_PROJECT_DEFAULT = "sotalab-prod"
+MODEL_DEFAULT = "doubao-seed-2-0-pro-260215"
+K_DEFAULT = 3
+N_TASKS_DEFAULT = 5
+
+
+def gcs_path(bucket: str, *parts: str) -> str:
+    return f"gs://{bucket}/" + "/".join(p.strip("/") for p in parts)
+
+
+def local_state_dir(project_dir: str) -> Path:
+    name = project_dir.replace("/", "__")
+    return Path.home() / ".archipelago-eval" / name
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def require_storage():
+    try:
+        from google.cloud import storage
+    except ImportError as exc:
+        raise SystemExit(
+            "google-cloud-storage is required for this command. "
+            "Run through `uv run python scripts/local_scheduler.py ...` "
+            "or install `google-cloud-storage` in the active Python environment."
+        ) from exc
+    return storage
+
+
+def require_hf_hub_download():
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:
+        raise SystemExit(
+            "huggingface_hub is required for `publish`. "
+            "Run through `uv run python scripts/local_scheduler.py publish ...` "
+            "or install `huggingface_hub` in the active Python environment."
+        ) from exc
+    return hf_hub_download
+
+
+def cmd_publish(args: argparse.Namespace) -> int:
+    """Sample N tasks, generate K*N jobs, and write scheduler state to GCS."""
+    project_dir = args.project_dir
+    bucket = args.bucket
+    project = args.gcp_project
+    model = args.model
+    k = args.k
+    n_tasks = args.n_tasks
+
+    eval_id = f"eval-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+    state_dir = local_state_dir(project_dir)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    hf_hub_download = require_hf_hub_download()
+    storage = require_storage()
+
+    # Download tasks
+    print(f"[publish] downloading tasks_and_rubrics.json from HF...")
+    tasks_path = hf_hub_download(
+        "mercor/apex-agents", "tasks_and_rubrics.json", repo_type="dataset"
+    )
+    tasks = json.load(open(tasks_path))
+    print(f"[publish] total tasks available: {len(tasks)}")
+
+    rng = random.Random(args.seed)
+    sampled = rng.sample(tasks, n_tasks)
+    sampled_path = state_dir / "sampled_tasks.json"
+    sampled_path.write_text(json.dumps([t["task_id"] for t in sampled], indent=2))
+    print(f"[publish] sampled {n_tasks} tasks (seed={args.seed}): "
+          f"{[t['task_id'] for t in sampled]}")
+
+    # Build jobs
+    jobs = []
+    for t in sampled:
+        for attempt in range(1, k + 1):
+            jobs.append({
+                "eval_id": eval_id,
+                "task_id": t["task_id"],
+                "task_name": t.get("task_name"),
+                "model": model,
+                "attempt": attempt,
+                "force_rerun": bool(args.force_rerun),
+                "job_id": f"{t['task_id']}-a{attempt}",
+                "published_at": now_iso(),
+            })
+
+    print(f"[publish] prepared {len(jobs)} jobs for GCS queue workers")
+
+    # Save scheduler state locally.
+    (state_dir / "jobs.json").write_text(json.dumps(jobs, indent=2))
+    task_ids = [{"task_id": t["task_id"], "model": model} for t in sampled]
+    (state_dir / "task_ids.json").write_text(json.dumps(task_ids, indent=2))
+
+    # Update GCS state used by dynamic queue workers and status/aggregate.
+    client = storage.Client(project=project)
+    bucket_obj = client.bucket(bucket)
+    bucket_obj.blob(f"{project_dir}/state/jobs.json").upload_from_string(
+        json.dumps(jobs, indent=2),
+        content_type="application/json",
+    )
+    bucket_obj.blob(f"{project_dir}/state/task_ids.json").upload_from_string(
+        json.dumps(task_ids, indent=2),
+        content_type="application/json",
+    )
+    manifest_blob = bucket_obj.blob(f"{project_dir}/state/manifest.json")
+    manifest_blob.upload_from_string(
+        json.dumps({
+            "eval_id": eval_id,
+            "project_dir": project_dir,
+            "model": model,
+            "k": k,
+            "n_tasks": n_tasks,
+            "sampled_tasks": [t["task_id"] for t in sampled],
+            "jobs": jobs,
+            "prepared_at": now_iso(),
+            "status": "prepared",
+            "queue": "gcs",
+        }, indent=2),
+        content_type="application/json",
+    )
+    print(f"[publish] manifest written to gs://{bucket}/{project_dir}/state/manifest.json")
+    print(f"[publish] task ids written to gs://{bucket}/{project_dir}/state/task_ids.json")
+    print("[publish] DONE. Start workers with 'make dynamic-workers' and monitor with 'make status'.")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Print progress: published, pending, done (with scores)."""
+    state_dir = local_state_dir(args.project_dir)
+    jobs_path = state_dir / "jobs.json"
+    if not jobs_path.exists():
+        print(f"[status] no jobs.json at {jobs_path}. Run 'publish' first.")
+        return 1
+    jobs = json.loads(jobs_path.read_text())
+    storage = require_storage()
+    client = storage.Client(project=args.gcp_project)
+    bucket_obj = client.bucket(args.bucket)
+    status_by_job: dict[str, dict] = {}
+    for j in jobs:
+        path = (
+            f"{args.project_dir}/results/{j['task_id']}/attempt{j['attempt']}/status.tsv"
+        )
+        blob = bucket_obj.blob(path)
+        if blob.exists():
+            data = blob.download_as_text()
+            entry = {"gcs": True}
+            for line in data.splitlines():
+                if "\t" in line:
+                    k, v = line.split("\t", 1)
+                    entry[k] = v
+            status_by_job[j["job_id"]] = entry
+        else:
+            status_by_job[j["job_id"]] = {"gcs": False}
+
+    n_pub = len(jobs)
+    n_done = sum(1 for s in status_by_job.values()
+                 if s.get("run_status") == "completed")
+    n_failed = sum(1 for s in status_by_job.values()
+                   if s.get("run_status") == "error")
+    n_pending = n_pub - n_done - n_failed
+
+    print(f"\n=== STATUS  ({now_iso()}) ===")
+    print(f"  published : {n_pub}")
+    print(f"  completed : {n_done}")
+    print(f"  failed    : {n_failed}")
+    print(f"  pending   : {n_pending}")
+    print()
+    print(f"  {'job_id':<60} {'status':<12} {'score':<6} {'worker':<25}")
+    print("  " + "-" * 105)
+    for j in jobs:
+        s = status_by_job.get(j["job_id"], {})
+        status = s.get("run_status", "pending")
+        score = "—"
+        if status == "completed":
+            # try to read grades.json
+            gp = (
+                f"{args.project_dir}/results/{j['task_id']}/attempt{j['attempt']}/grades.json"
+            )
+            gblob = bucket_obj.blob(gp)
+            if gblob.exists():
+                g = json.loads(gblob.download_as_text())
+                score = f"{g.get('scoring_results',{}).get('final_score',0):.2f}"
+        worker = s.get("worker_id", "—")
+        print(f"  {j['job_id']:<60} {status:<12} {score:<6} {worker:<25}")
+    return 0
+
+
+def cmd_aggregate(args: argparse.Namespace) -> int:
+    """Download all grades.json, compute per-task pass@1/pass@3/mean score."""
+    storage = require_storage()
+    client = storage.Client(project=args.gcp_project)
+    bucket_obj = client.bucket(args.bucket)
+    state_dir = local_state_dir(args.project_dir)
+    jobs_path = state_dir / "jobs.json"
+    if not jobs_path.exists():
+        print(f"[aggregate] no jobs.json; run 'publish' first")
+        return 1
+    jobs = json.loads(jobs_path.read_text())
+    by_task: dict[str, list[dict]] = collections.defaultdict(list)
+    for j in jobs:
+        gp = (
+            f"{args.project_dir}/results/{j['task_id']}/attempt{j['attempt']}/grades.json"
+        )
+        gblob = bucket_obj.blob(gp)
+        if gblob.exists():
+            g = json.loads(gblob.download_as_text())
+            score = g.get("scoring_results", {}).get("final_score")
+        else:
+            score = None
+        by_task[j["task_id"]].append({
+            "attempt": j["attempt"],
+            "model": j["model"],
+            "score": score,
+        })
+
+    print(f"\n=== AGGREGATE  ({now_iso()}) ===")
+    print(f"  {'task_id':<50} {'name':<40} {'pass@1':<8} {'pass@3':<8} {'mean':<6}")
+    print("  " + "-" * 120)
+    summary_rows = []
+    for tid, runs in by_task.items():
+        scores = [r["score"] for r in runs if isinstance(r["score"], (int, float))]
+        n = len(scores)
+        pass_1 = sum(1 for s in scores if s >= 1.0) / n if n else 0
+        # pass@k: any run scored 1.0 among the k attempts
+        pass_k = 1 if any(s >= 1.0 for s in scores) else 0
+        mean = sum(scores) / n if n else 0
+        name = runs[0].get("task_name") or tid
+        summary_rows.append({
+            "task_id": tid,
+            "task_name": name,
+            "n_attempts_scored": n,
+            "pass_at_1": pass_1,
+            "pass_at_k": pass_k,
+            "mean_score": mean,
+            "scores": scores,
+        })
+        print(f"  {tid:<50} {name[:38]:<40} {pass_1:.2f}     {pass_k:.2f}     {mean:.2f}")
+
+    overall_n = sum(r["n_attempts_scored"] for r in summary_rows)
+    overall_pass1 = (sum(r["pass_at_1"] * r["n_attempts_scored"]
+                         for r in summary_rows) / overall_n) if overall_n else 0
+    overall_passk = (sum(r["pass_at_k"] for r in summary_rows)
+                     / len(summary_rows)) if summary_rows else 0
+    overall_mean = (sum(r["mean_score"] * r["n_attempts_scored"]
+                        for r in summary_rows) / overall_n) if overall_n else 0
+    print(f"\n  OVERALL   pass@1={overall_pass1:.2f}  pass@k={overall_passk:.2f}  mean={overall_mean:.2f}  (n_scored={overall_n})")
+
+    out = {
+        "generated_at": now_iso(),
+        "project_dir": args.project_dir,
+        "model": jobs[0]["model"] if jobs else None,
+        "k": max(len(runs) for runs in by_task.values()) if by_task else 0,
+        "per_task": summary_rows,
+        "overall": {
+            "pass_at_1": overall_pass1,
+            "pass_at_k": overall_passk,
+            "mean_score": overall_mean,
+            "n_attempts_scored": overall_n,
+        },
+    }
+    out_path = state_dir / "summary.json"
+    out_path.write_text(json.dumps(out, indent=2))
+    print(f"\n  summary.json -> {out_path}")
+
+    # Upload to GCS too
+    bucket_obj.blob(f"{args.project_dir}/state/summary.json").upload_from_string(
+        json.dumps(out, indent=2),
+        content_type="application/json",
+    )
+    print(f"  gs://{args.bucket}/{args.project_dir}/state/summary.json")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project-dir", default=PROJECT_DIR_DEFAULT)
+    parser.add_argument("--bucket", default=BUCKET_DEFAULT)
+    parser.add_argument("--gcp-project", default=GCP_PROJECT_DEFAULT)
+    parser.add_argument(
+        "--pubsub-project",
+        dest="gcp_project",
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("publish")
+    p.add_argument("--n-tasks", type=int, default=N_TASKS_DEFAULT)
+    p.add_argument("--k", type=int, default=K_DEFAULT)
+    p.add_argument("--model", default=MODEL_DEFAULT)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--force-rerun", action="store_true")
+    p.set_defaults(func=cmd_publish)
+
+    s = sub.add_parser("status")
+    s.set_defaults(func=cmd_status)
+
+    a = sub.add_parser("aggregate")
+    a.set_defaults(func=cmd_aggregate)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/monitor_gcs.py
+++ b/scripts/monitor_gcs.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+GCS-backed status monitor for archipelago eval jobs.
+
+Polls gs://<bucket>/<project>/results/*/attempt*/status.tsv every N seconds.
+No SSH, no Pub/Sub — just GCS.
+
+Usage:
+    python scripts/monitor_gcs.py \
+        --bucket sotalab-archipelago-eval \
+        --project-dir eval-projects/seed-pro-pass3-20260616 \
+        [--interval 30]
+
+Prints a live table showing each (task, attempt):
+  - status (pending / running / completed / error / failed)
+  - final_score (if grades.json available)
+  - worker_id (from status.tsv)
+  - duration (s)
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from google.cloud import storage
+
+
+def list_jobs_from_manifest(bucket, project_dir: str) -> list[dict[str, Any]]:
+    """Read jobs list from state/manifest.json if present, else infer from GCS results/."""
+    blob = bucket.blob(f"{project_dir}/state/manifest.json")
+    if blob.exists():
+        try:
+            data = json.loads(blob.download_as_text())
+            return data.get("jobs", [])
+        except Exception:
+            pass
+    # Fallback: scan GCS results/ tree
+    jobs = []
+    blobs = client.list_blobs(bucket.name, prefix=f"{project_dir}/results/")
+    seen = set()
+    for b in blobs:
+        parts = b.name.split("/")
+        # results/<task_id>/attempt<N>/<file>
+        if len(parts) >= 4 and parts[0] == "results":
+            task_id, attempt_dir = parts[1], parts[2]
+            if attempt_dir.startswith("attempt"):
+                key = (task_id, attempt_dir)
+                if key not in seen:
+                    seen.add(key)
+                    attempt = int(attempt_dir.replace("attempt", ""))
+                    jobs.append({"task_id": task_id, "attempt": attempt, "model": "?"})
+    return jobs
+
+
+def read_status_tsv(bucket, project_dir: str, task_id: str, attempt: int) -> dict[str, str]:
+    """Read status.tsv from GCS, return {field: value} dict."""
+    blob = bucket.blob(f"{project_dir}/results/{task_id}/attempt{attempt}/status.tsv")
+    if not blob.exists():
+        return {}
+    try:
+        text = blob.download_as_text()
+    except Exception:
+        return {}
+    result = {}
+    for line in text.splitlines():
+        if "\t" in line:
+            k, v = line.split("\t", 1)
+            result[k] = v
+    return result
+
+
+def read_grades(bucket, project_dir: str, task_id: str, attempt: int) -> float | None:
+    blob = bucket.blob(f"{project_dir}/results/{task_id}/attempt{attempt}/grades.json")
+    if not blob.exists():
+        return None
+    try:
+        g = json.loads(blob.download_as_text())
+        return g.get("scoring_results", {}).get("final_score")
+    except Exception:
+        return None
+
+
+def render_row(job: dict, status: dict, score: float | None) -> str:
+    task_id = job["task_id"]
+    attempt = job["attempt"]
+    model = job.get("model", "?")
+    if score is not None:
+        run_status = "completed"
+        score_str = f"{score:.2f}"
+    else:
+        run_status = status.get("run_status", "pending")
+        score_str = "—"
+    worker = status.get("worker_id", "—")[:18]
+    dur = status.get("agent_exit", "—")
+    return f"  {task_id[:48]:<48} a{attempt:<2} {model[:24]:<24} {run_status:<10} {score_str:<6} {worker:<18} {dur}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bucket", default="sotalab-archipelago-eval")
+    ap.add_argument("--project-dir", default="eval-projects/seed-pro-pass3-20260616")
+    ap.add_argument("--project", default="sotalab-prod")
+    ap.add_argument("--interval", type=int, default=30, help="poll interval seconds")
+    ap.add_argument("--once", action="store_true")
+    args = ap.parse_args()
+
+    client = storage.Client(project=args.project)
+    bucket = client.bucket(args.bucket)
+
+    while True:
+        jobs = list_jobs_from_manifest(bucket, args.project_dir)
+        if not jobs:
+            print(f"  (no jobs found under {args.bucket}/{args.project_dir}/)")
+            if args.once:
+                return 0
+            time.sleep(args.interval)
+            continue
+        print("\n" + "=" * 130)
+        print(f"  archipelago eval  {args.bucket}/{args.project_dir}  ({len(jobs)} jobs)")
+        print(f"  {'task_id':<48} {'at':<3} {'model':<24} {'status':<10} {'score':<6} {'worker':<18} {'exit'}")
+        print("  " + "-" * 128)
+        for j in jobs:
+            status = read_status_tsv(bucket, args.project_dir, j["task_id"], j["attempt"])
+            score = read_grades(bucket, args.project_dir, j["task_id"], j["attempt"])
+            print(render_row(j, status, score))
+        n_completed = sum(
+            1 for j in jobs
+            if read_grades(bucket, args.project_dir, j["task_id"], j["attempt"]) is not None
+        )
+        print(f"\n  completed: {n_completed}/{len(jobs)}")
+        if args.once:
+            return 0
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pass8_tail_watcher.py
+++ b/scripts/pass8_tail_watcher.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Wait for pass@5 artifacts, then run the pass@8 tail attempts.
+
+This is meant to run as a lightweight systemd service on each worker VM. All
+workers can run the watcher concurrently; once pass@5 is complete they all enter
+the same GCS-backed pass8 queue, and claim creation keeps work distributed.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from google.cloud import storage
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("pass8_tail_watcher")
+
+
+def count_complete_attempts(
+    client: storage.Client,
+    bucket_name: str,
+    project_dir: str,
+    attempt_start: int,
+    attempt_end: int,
+) -> tuple[int, int]:
+    required = {"status.tsv", "grades.json", "trajectory.json"}
+    seen: dict[tuple[str, int], set[str]] = {}
+    prefix = f"{project_dir}/results/"
+    for blob in client.list_blobs(bucket_name, prefix=prefix):
+        parts = blob.name.split("/")
+        if len(parts) < 5:
+            continue
+        try:
+            result_idx = parts.index("results")
+        except ValueError:
+            continue
+        if result_idx + 3 >= len(parts):
+            continue
+        task_id = parts[result_idx + 1]
+        attempt_part = parts[result_idx + 2]
+        filename = parts[result_idx + 3]
+        if not task_id.startswith("task_") or not attempt_part.startswith("attempt"):
+            continue
+        try:
+            attempt = int(attempt_part.removeprefix("attempt"))
+        except ValueError:
+            continue
+        if attempt_start <= attempt <= attempt_end and filename in required:
+            seen.setdefault((task_id, attempt), set()).add(filename)
+    complete = sum(1 for files in seen.values() if required <= files)
+    target = 160 * (attempt_end - attempt_start + 1)
+    return complete, target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Start pass8 tail queue after pass5 completes")
+    parser.add_argument("--jobs-file", required=True)
+    parser.add_argument("--project-dir", required=True)
+    parser.add_argument("--bucket", default="sotalab-archipelago-eval")
+    parser.add_argument("--wait-attempt-start", type=int, default=1)
+    parser.add_argument("--wait-attempt-end", type=int, default=5)
+    parser.add_argument("--queue-name", default="pass8")
+    parser.add_argument("--attempt-start", type=int, default=6)
+    parser.add_argument("--attempt-end", type=int, default=8)
+    parser.add_argument("--model", default="doubao-seed-2-0-pro-260215")
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--max-steps", type=int, default=200)
+    parser.add_argument("--max-consecutive-failures", type=int, default=2)
+    parser.add_argument("--sleep-seconds", type=int, default=300)
+    parser.add_argument("--archipelago-dir", default="/opt/archipelago")
+    args = parser.parse_args()
+
+    client = storage.Client()
+    while True:
+        complete, target = count_complete_attempts(
+            client,
+            args.bucket,
+            args.project_dir,
+            args.wait_attempt_start,
+            args.wait_attempt_end,
+        )
+        log.info(
+            "pass5 gate: complete=%d target=%d missing=%d",
+            complete,
+            target,
+            target - complete,
+        )
+        if complete >= target:
+            break
+        time.sleep(args.sleep_seconds)
+
+    archipelago_dir = Path(args.archipelago_dir)
+    cmd = [
+        sys.executable,
+        str(archipelago_dir / "scripts" / "worker_queue.py"),
+        "--jobs-file",
+        args.jobs_file,
+        "--project-dir",
+        args.project_dir,
+        "--bucket",
+        args.bucket,
+        "--queue-name",
+        args.queue_name,
+        "--attempt-start",
+        str(args.attempt_start),
+        "--attempt-end",
+        str(args.attempt_end),
+        "--model",
+        args.model,
+        "--temperature",
+        str(args.temperature),
+        "--max-steps",
+        str(args.max_steps),
+        "--shuffle",
+        "--max-consecutive-failures",
+        str(args.max_consecutive_failures),
+    ]
+    log.info("starting pass8 tail queue: %s", " ".join(cmd))
+    return subprocess.run(cmd, cwd=archipelago_dir).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probe_new_api.sh
+++ b/scripts/probe_new_api.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Probe SoTALab New API staging model availability + a tiny completion.
+#
+# Verifies that the New API token can be fetched from Secret Manager, that
+# the candidate models respond with sane tokens, and reports per-model
+# latency + token count.
+#
+# Usage: ./scripts/probe_new_api.sh [model_id ...]
+#   defaults to the models used in this repo's tests
+
+set -uo pipefail
+
+PROJECT="${PROJECT:-sotalab-staging}"
+SECRET="${SECRET:-NEW_API_TOKEN-staging}"
+BASE="${BASE:-https://new-api-staging.sotalab.ai/v1}"
+
+MODELS=("$@")
+if [[ ${#MODELS[@]} -eq 0 ]]; then
+  MODELS=(
+    "doubao-seed-2-0-pro-260215"
+    "qwen3.6-27b"
+    "qwen3.7-max"
+    "gpt-5.4"
+  )
+fi
+
+echo "============================================================"
+echo " New API probe"
+echo "   base    : $BASE"
+echo "   secret  : $SECRET (project=$PROJECT)"
+echo "============================================================"
+
+TOKEN="$(gcloud secrets versions access latest \
+  --project="$PROJECT" --secret="$SECRET" 2>/dev/null || true)"
+if [[ -z "$TOKEN" ]]; then
+  echo "ERROR: failed to fetch token from Secret Manager"
+  exit 1
+fi
+echo "  token    : <${#TOKEN} chars>"
+echo
+
+# List endpoint
+echo "  models endpoint (/v1/models):"
+curl -sS "$BASE/models" \
+  -H "Authorization: Bearer $TOKEN" \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+ids = sorted({m['id'] for m in d.get('data', [])})
+print(f'    {len(ids)} models:')
+for i in ids:
+    print(f'      - {i}')
+"
+echo
+
+# Per-model completion probe
+echo "  per-model smoke test:"
+for m in "${MODELS[@]}"; do
+  echo "    $m"
+  t0=$(date +%s%N)
+  resp=$(curl -sS "$BASE/chat/completions" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -w '\n__HTTP_CODE__:%{http_code}\n__TIME__:%{time_total}\n' \
+    -d "{
+      \"model\": \"$m\",
+      \"messages\": [{\"role\": \"user\", \"content\": \"Reply with one word: ok\"}],
+      \"max_tokens\": 30
+    }")
+  t1=$(date +%s%N)
+  http_code=$(echo "$resp" | grep '__HTTP_CODE__' | cut -d: -f2)
+  curl_time=$(echo "$resp" | grep '__TIME__' | cut -d: -f2)
+  body=$(echo "$resp" | grep -v '__HTTP_CODE__\|__TIME__')
+  if [[ "$http_code" == "200" ]]; then
+    content=$(echo "$body" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d['choices'][0]['message']['content'][:50])
+except Exception as e:
+    print(f'<parse err: {e}>')
+")
+    usage=$(echo "$body" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    u = d.get('usage', {})
+    print(f\"in={u.get('prompt_tokens','?')} out={u.get('completion_tokens','?')} total={u.get('total_tokens','?')}\")
+except: pass
+" 2>/dev/null)
+    printf "      HTTP %s  time=%ss  reply=%-20s  %s\n" \
+      "$http_code" "$curl_time" "\"$content\"" "$usage"
+  else
+    printf "      HTTP %s  FAILED: %s\n" "$http_code" \
+      "$(echo "$body" | head -c 200)"
+  fi
+done
+
+echo
+echo "  done."

--- a/scripts/run_single_task.py
+++ b/scripts/run_single_task.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Run a single (task, model, attempt) Archipelago evaluation.
+
+Wraps examples/hugging_face_task/main.py with:
+  - per-worker compose project name isolation
+  - per-attempt output directory
+  - GCS upload of trajectory/snapshot/grades to eval-projects/<project_dir>/results/<task_id>/attempt<N>/
+  - GCS upload of worker's run.log
+
+Usage:
+    python scripts/run_single_task.py \
+        --task-id task_abc123 \
+        --model doubao-seed-2-0-pro-260215 \
+        --attempt 1 \
+        --worker-id worker-1 \
+        --eval-project seed-pro-pass3-20260616 \
+        --bucket sotalab-archipelago-eval \
+        --project-dir eval-projects/seed-pro-pass3-20260616
+
+Environment overrides recognized from main.py (forwarded via env):
+  ENV_URL=http://localhost:8080  (default)
+  COMPOSE_PROJECT_NAME=archipelago-w<worker_id>
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_DIR = REPO_ROOT / "examples" / "hugging_face_task"
+ENVIRONMENT_DIR = REPO_ROOT / "environment"
+AGENTS_DIR = REPO_ROOT / "agents"
+GRADING_DIR = REPO_ROOT / "grading"
+
+
+def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> int:
+    """Run a shell command, return returncode. Stream output if not captured."""
+    print(f"  $ {' '.join(cmd)}", flush=True)
+    res = subprocess.run(cmd, cwd=cwd)
+    return res.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a single Archipelago task")
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--attempt", required=True, type=int)
+    parser.add_argument("--worker-id", required=True)
+    parser.add_argument("--eval-project", required=True,
+                        help="Eval project name (subdir under eval-projects/)")
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--project-dir", required=True,
+                        help="Full GCS prefix, e.g. eval-projects/seed-pro-pass3-20260616")
+    parser.add_argument("--max-steps", type=int, default=200,
+                        help="Agent max_steps (default 200)")
+    parser.add_argument("--temperature", type=float, default=None,
+                        help="Optional orchestrator temperature; defaults to ORCHESTRATOR_TEMPERATURE if set")
+    parser.add_argument("--rerun", action="store_true",
+                        help="Wipe local output + GCS result dir before running")
+    args = parser.parse_args()
+
+    compose_project = f"archipelago-w{args.worker_id}"
+    gcs_results = (
+        f"gs://{args.bucket}/{args.project_dir}/results/{args.task_id}/attempt{args.attempt}"
+    )
+
+    print("=" * 60, flush=True)
+    print(f"Worker: {args.worker_id}  Compose: {compose_project}", flush=True)
+    print(f"Task: {args.task_id}  Model: {args.model}  Attempt: {args.attempt}", flush=True)
+    print(f"GCS results: {gcs_results}", flush=True)
+    print("=" * 60, flush=True)
+
+    # Per-attempt output dir under example dir
+    output_dir = EXAMPLE_DIR / "output" / args.task_id / f"attempt{args.attempt}"
+    if args.rerun and output_dir.exists():
+        print(f"  --rerun: wiping {output_dir}", flush=True)
+        subprocess.run(["rm", "-rf", str(output_dir)], check=False)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build per-run orchestrator config (model string for LiteLLM proxy)
+    orchestrator_config_path = output_dir / "orchestrator_config.json"
+    orchestrator_config = {"model": args.model}
+    temperature = args.temperature
+    if temperature is None and os.environ.get("ORCHESTRATOR_TEMPERATURE"):
+        temperature = float(os.environ["ORCHESTRATOR_TEMPERATURE"])
+    if temperature is not None:
+        orchestrator_config["extra_args"] = {"temperature": temperature}
+    orchestrator_config_path.write_text(json.dumps(orchestrator_config, indent=2) + "\n")
+
+    # Build a worker_id-tagged agent_config.json so the trajectory logs the worker
+    agent_config_path = output_dir / "agent_config.json"
+    agent_config_path.write_text(
+        '{\n'
+        '  "agent_config_id": "react_toolbelt_agent",\n'
+        '  "agent_name": "React Toolbelt Agent",\n'
+        f'  "agent_config_values": {{"timeout": 3600, "max_steps": {args.max_steps}, "worker_id": "{args.worker_id}"}}\n'
+        '}\n'
+    )
+
+    # Environment for the main.py subprocess: compose project + agent config
+    env = os.environ.copy()
+    env["COMPOSE_PROJECT_NAME"] = compose_project
+    env["AGENT_CONFIG"] = str(agent_config_path)
+    env["ORCHESTRATOR_CONFIG"] = str(orchestrator_config_path)
+    env["ARCHIPELAGO_OUTPUT_DIR"] = str(output_dir)
+    # HuggingFace token: if file exists at $HOME/.cache/huggingface/token,
+    # read it into env so uv-run subprocess inherits it.
+    hf_token_path = Path.home() / ".cache" / "huggingface" / "token"
+    if hf_token_path.exists():
+        token_val = hf_token_path.read_text().strip()
+        env["HF_TOKEN"] = token_val
+        print(f"  HF_TOKEN read from {hf_token_path} (len={len(token_val)})", flush=True)
+
+    # Forward LITELLM_PROXY_API_BASE / KEY from current env so the agent
+    # runner (which reads agents/.env via pydantic_settings) actually sees
+    # the New API proxy instead of falling back to default Vertex AI.
+    for k in ("LITELLM_PROXY_API_BASE", "LITELLM_PROXY_API_KEY", "AGENT_TIMEOUT_SECONDS"):
+        if k in os.environ:
+            env[k] = os.environ[k]
+
+    # The main.py script writes to a hardcoded output/<task_id>/ — we work
+    # around by passing the task_id, then rsyncing output/<task_id>/<attempt_dir>
+    # afterwards. Easiest: just run main.py and move the per-task output into our
+    # attempt dir after.
+    log_path = output_dir / "run.log"
+    with open(log_path, "w") as logf:
+        cmd = [
+            "uv", "run", "python", str(EXAMPLE_DIR / "main.py"),
+            args.task_id,
+        ]
+        print(f"  $ {' '.join(cmd)}  (log -> {log_path})", flush=True)
+        res = subprocess.run(
+            cmd,
+            cwd=AGENTS_DIR,
+            env=env,
+            stdout=logf,
+            stderr=subprocess.STDOUT,
+        )
+
+    run_status = "error"
+    if res.returncode == 0:
+        run_status = "completed"
+    print(f"  agent exit={res.returncode} status={run_status}", flush=True)
+
+    # Move everything main.py wrote under output/<task_id>/ into our attempt dir.
+    main_output = EXAMPLE_DIR / "output" / args.task_id
+    if main_output.exists():
+        for f in main_output.iterdir():
+            if f.name == f"attempt{args.attempt}":
+                continue
+            target = output_dir / f.name
+            if target.exists():
+                continue
+            shutil.move(str(f), str(target))
+        try:
+            main_output.rmdir()
+        except OSError:
+            pass
+
+    # Upload to GCS
+    upload_prefix = gcs_results
+    print(f"  uploading {output_dir} -> {upload_prefix}/ ...", flush=True)
+    rc = subprocess.run(
+        ["gsutil", "-m", "cp", "-r", str(output_dir) + "/", upload_prefix + "/"],
+    ).returncode
+    if rc != 0:
+        print(f"  WARNING: gsutil cp returned {rc}", flush=True)
+
+    # Write status sentinel into GCS
+    status_blob = (
+        f"attempt\t{args.attempt}\n"
+        f"task_id\t{args.task_id}\n"
+        f"model\t{args.model}\n"
+        f"worker_id\t{args.worker_id}\n"
+        f"agent_exit\t{res.returncode}\n"
+        f"run_status\t{run_status}\n"
+    )
+    status_path = output_dir / "status.tsv"
+    status_path.write_text(status_blob)
+    subprocess.run(
+        ["gsutil", "cp", str(status_path), f"{upload_prefix}/status.tsv"],
+    )
+
+    # Keep key artifacts flat under attempt<N>/ as well as in the recursive
+    # attempt<N>/attempt<N>/ copy. worker_shard.py uses these flat paths for
+    # cheap GCS resume checks.
+    for artifact in (
+        "trajectory.json",
+        "grades.json",
+        "final_snapshot.zip",
+        "verifiers.json",
+        "run.log",
+    ):
+        artifact_path = output_dir / artifact
+        if artifact_path.exists():
+            subprocess.run(
+                ["gsutil", "cp", str(artifact_path), f"{upload_prefix}/{artifact}"],
+            )
+
+    print("=" * 60, flush=True)
+    print(f"DONE  status={run_status}  gcs={upload_prefix}/", flush=True)
+    print("=" * 60, flush=True)
+
+    return 0 if run_status == "completed" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scale_down_eval_workers.sh
+++ b/scripts/scale_down_eval_workers.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Stop running Archipelago eval worker VMs to reduce idle GCE cost.
+#
+# Usage:
+#   archipelago/scripts/scale_down_eval_workers.sh
+#   DRY_RUN=1 archipelago/scripts/scale_down_eval_workers.sh
+#   WORKER_PREFIX=archipelago-eval-auto archipelago/scripts/scale_down_eval_workers.sh
+
+set -euo pipefail
+
+PROJECT="${PROJECT:-$(gcloud config get-value project 2>/dev/null)}"
+WORKER_PREFIX="${WORKER_PREFIX:-archipelago-eval}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [[ -z "${PROJECT}" ]]; then
+  echo "PROJECT is empty. Set PROJECT or run: gcloud config set project <project-id>" >&2
+  exit 1
+fi
+
+RUNNING_WORKERS=()
+while IFS= read -r line; do
+  [[ -n "${line}" ]] && RUNNING_WORKERS+=("${line}")
+done < <(
+  gcloud compute instances list \
+    --project="${PROJECT}" \
+    --filter="name~^${WORKER_PREFIX} AND status=RUNNING" \
+    --format="csv[no-heading](name,zone)"
+)
+
+if [[ "${#RUNNING_WORKERS[@]}" -eq 0 ]]; then
+  echo "[scale-down] no RUNNING instances found for prefix '${WORKER_PREFIX}' in project '${PROJECT}'"
+  exit 0
+fi
+
+echo "[scale-down] project=${PROJECT} prefix=${WORKER_PREFIX}"
+printf '%s\n' "${RUNNING_WORKERS[@]}" | awk -F, '{printf "  - %s (%s)\n", $1, $2}'
+
+if [[ "${DRY_RUN}" == "1" || "${DRY_RUN}" == "true" ]]; then
+  echo "[scale-down] DRY_RUN enabled; no instances stopped"
+  exit 0
+fi
+
+ZONES=()
+while IFS= read -r zone; do
+  [[ -n "${zone}" ]] && ZONES+=("${zone}")
+done < <(printf '%s\n' "${RUNNING_WORKERS[@]}" | awk -F, '{print $2}' | sort -u)
+
+for zone in "${ZONES[@]}"; do
+  NAMES=()
+  while IFS= read -r name; do
+    [[ -n "${name}" ]] && NAMES+=("${name}")
+  done < <(
+    printf '%s\n' "${RUNNING_WORKERS[@]}" \
+      | awk -F, -v zone="${zone}" '$2 == zone {print $1}'
+  )
+  if [[ "${#NAMES[@]}" -eq 0 ]]; then
+    continue
+  fi
+  echo "[scale-down] stopping ${#NAMES[@]} instance(s) in ${zone}: ${NAMES[*]}"
+  gcloud compute instances stop "${NAMES[@]}" \
+    --project="${PROJECT}" \
+    --zone="${zone}" \
+    --quiet
+done
+
+echo "[scale-down] final status"
+gcloud compute instances list \
+  --project="${PROJECT}" \
+  --filter="name~^${WORKER_PREFIX}" \
+  --format="table(name,zone,machineType.basename(),status)"

--- a/scripts/scan_precision_near_miss.py
+++ b/scripts/scan_precision_near_miss.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Scan grades.json files for strict numeric precision near-misses."""
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+
+NUM_RE = re.compile(
+    r"(?P<prefix>[$€£~≈]?\s*)"
+    r"(?P<num>-?\d+(?:,\d{3})*(?:\.\d+)?)"
+    r"(?P<suffix>\s*(?:%|x|MM|million|billion|m|bps|Euros?|EUR)?)",
+    re.IGNORECASE,
+)
+
+
+def clean_num(raw: str) -> float:
+    return float(raw.replace(",", ""))
+
+
+def decimals(raw: str) -> int:
+    raw = raw.replace(",", "")
+    return len(raw.split(".", 1)[1]) if "." in raw else 0
+
+
+def is_year(text: str, start: int, end: int, value: float) -> bool:
+    if not 1900 <= abs(value) <= 2100:
+        return False
+    ctx = text[max(0, start - 8) : min(len(text), end + 8)]
+    return bool(re.search(r"(20\d\d\s*[EA]?|FY\s*20\d\d|20\d\dE|20\d\dA|year|\b20\d\d\b)", ctx, re.I))
+
+
+def extract_numbers(text: str, section: str) -> list[dict[str, Any]]:
+    numbers: list[dict[str, Any]] = []
+    for match in NUM_RE.finditer(text):
+        raw = match.group("num")
+        value = clean_num(raw)
+        if is_year(text, match.start(), match.end(), value):
+            continue
+        numbers.append(
+            {
+                "val": value,
+                "raw": raw,
+                "dp": decimals(raw),
+                "unit": (match.group("prefix") + match.group("suffix")).strip(),
+                "section": section,
+                "ctx": text[max(0, match.start() - 55) : min(len(text), match.end() + 55)],
+                "pos": match.start(),
+            }
+        )
+    return numbers
+
+
+def criterion_requirement(rationale: str) -> str:
+    match = re.search(r"criterion requirement:\s*(.*)", rationale, re.IGNORECASE | re.DOTALL)
+    if not match:
+        return ""
+    text = match.group(1).strip()
+    # Stop before conclusion text even when the judge emits everything on one line.
+    text = re.split(r"(?:\n|\s)-?\s*Conclusion:|\s+Conclusion:", text, maxsplit=1, flags=re.IGNORECASE)[0]
+    text = re.split(r"\n\s*-?\s*(?:Assessment|Evidence):", text, maxsplit=1, flags=re.IGNORECASE)[0]
+    return text.strip()
+
+
+def target_part(requirement: str) -> str:
+    matches = list(re.finditer(r"\b(?:is|are|equals?|equal to|be)\b", requirement, re.IGNORECASE))
+    return requirement[matches[-1].end() :] if matches else requirement
+
+
+def evidence_and_assessment(rationale: str) -> tuple[str, str]:
+    parts = re.split(r"## Assessment|Assessment:", rationale, flags=re.IGNORECASE)
+    evidence = parts[0]
+    assessment = parts[1] if len(parts) > 1 else ""
+    return evidence, assessment
+
+
+def unit_class(unit: str) -> str:
+    unit = unit.lower()
+    if "%" in unit or "bps" in unit:
+        return "pct"
+    if "x" in unit:
+        return "x"
+    if any(token in unit for token in ("$", "€", "£", "mm", "million", "billion", "eur", "euro")):
+        return "money"
+    return "plain"
+
+
+def compatible(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    ca = unit_class(str(a["unit"]))
+    cb = unit_class(str(b["unit"]))
+    return ca == "plain" or cb == "plain" or ca == cb
+
+
+def precision_unit(number: dict[str, Any]) -> float:
+    return 10 ** (-int(number["dp"]))
+
+
+def scan(grades_dir: Path, expected_attempts: int) -> dict[str, Any]:
+    files = [path for path in sorted(grades_dir.glob("task_*__attempt*.json")) if path.stat().st_size > 0]
+    rows: list[dict[str, Any]] = []
+    total = 0
+    failed = 0
+    skipped_no_req = 0
+    for path in files:
+        task_id, attempt_part = path.stem.split("__attempt", 1)
+        attempt = int(attempt_part)
+        payload = json.loads(path.read_text())
+        for index, result in enumerate(payload.get("verifier_results", []) or []):
+            total += 1
+            values = result.get("verifier_result_values", {}) or {}
+            rationale = str(values.get("grade_rationale", ""))
+            score = float(result.get("score") or 0.0)
+            judge_grade = str(values.get("judge_grade", "")).lower()
+            if not (score == 0.0 or judge_grade == "fail"):
+                continue
+            failed += 1
+            requirement = criterion_requirement(rationale)
+            if not requirement:
+                skipped_no_req += 1
+                continue
+            required_numbers = extract_numbers(target_part(requirement), "requirement")
+            if not required_numbers:
+                continue
+            evidence, assessment = evidence_and_assessment(rationale)
+            candidates = []
+            for number in extract_numbers(evidence, "evidence") + extract_numbers(assessment, "assessment"):
+                ctx = str(number["ctx"]).lower()
+                if any(
+                    marker in ctx
+                    for marker in (
+                        "criterion requirement",
+                        "required value",
+                        "required $",
+                        "instead of the required",
+                        "does not match the required",
+                    )
+                ):
+                    continue
+                candidates.append(number)
+            best: dict[str, Any] | None = None
+            for required in required_numbers:
+                for candidate in candidates:
+                    if not compatible(required, candidate):
+                        continue
+                    diff = abs(float(required["val"]) - float(candidate["val"]))
+                    if diff == 0:
+                        continue
+                    rel = diff / (abs(float(required["val"])) if required["val"] else 1.0)
+                    unit = max(precision_unit(required), precision_unit(candidate))
+                    strict = diff <= unit + 1e-9 and rel <= 0.001
+                    if max(int(required["dp"]), int(candidate["dp"])) == 0 and diff <= 1 + 1e-9 and rel <= 0.001:
+                        strict = True
+                    small = (not strict) and rel <= 0.001 and diff <= max(unit * 5, 0.5)
+                    if strict or small:
+                        rank = (0 if strict else 1, rel, diff)
+                        if best is None or rank < best["rank"]:
+                            best = {
+                                "task_id": task_id,
+                                "attempt": attempt,
+                                "verifier_index": index,
+                                "required": required,
+                                "provided": candidate,
+                                "diff": diff,
+                                "rel": rel,
+                                "unit_step": unit,
+                                "strict": strict,
+                                "small": small,
+                                "req_line": requirement,
+                                "rationale": rationale[:1200],
+                                "rank": rank,
+                            }
+            if best is not None:
+                rows.append(best)
+
+    strict_rows = [row for row in rows if row["strict"]]
+    small_rows = [row for row in rows if row["small"]]
+    summary = {
+        "valid_grade_files": len(files),
+        "missing_or_empty_grade_files": expected_attempts - len(files),
+        "verifier_total": total,
+        "failed_verifiers": failed,
+        "skipped_failed_without_req_line": skipped_no_req,
+        "strict_precision_near_miss": len(strict_rows),
+        "strict_share_failed": len(strict_rows) / failed if failed else None,
+        "strict_share_total": len(strict_rows) / total if total else None,
+        "small_numeric_delta_non_strict": len(small_rows),
+        "small_share_failed": len(small_rows) / failed if failed else None,
+        "combined_strict_plus_small": len(rows),
+        "combined_share_failed": len(rows) / failed if failed else None,
+        "strict_unique_tasks": len({row["task_id"] for row in strict_rows}),
+        "strict_unique_task_attempts": len({(row["task_id"], row["attempt"]) for row in strict_rows}),
+        "small_unique_tasks": len({row["task_id"] for row in small_rows}),
+    }
+    return {
+        "summary": summary,
+        "top_strict_tasks": [
+            {"task_id": task_id, "count": count}
+            for task_id, count in collections.Counter(row["task_id"] for row in strict_rows).most_common()
+        ],
+        "strict_diff_buckets": [
+            {"diff": diff, "count": count}
+            for diff, count in collections.Counter(round(float(row["diff"]), 6) for row in strict_rows).most_common()
+        ],
+        "rows": [{key: value for key, value in row.items() if key != "rank"} for row in rows],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--grades-dir", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--expected-attempts", type=int, default=1280)
+    args = parser.parse_args()
+    result = scan(Path(args.grades_dir), args.expected_attempts)
+    Path(args.output).write_text(json.dumps(result, ensure_ascii=False, indent=2) + "\n")
+    print(json.dumps(result["summary"], ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup_worker.sh
+++ b/scripts/setup_worker.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# GCE VM startup script for archipelago-eval worker.
+#
+# Embed this script as `startup-script` metadata when creating the VM.
+# It will:
+#   1. Install docker / uv / git / gsutil / python storage client
+#   2. Clone the archipelago repo
+#   3. Pull New API token from Secret Manager and write agents/.env
+#   4. Install agents + grading dependencies via uv
+#   5. Optionally register a dynamic GCS queue worker as a systemd service
+#
+# Required service-account roles:
+#   roles/storage.objectAdmin
+#   roles/secretmanager.secretAccessor
+#
+# Required env vars to set on the VM metadata (or replace inline):
+#   ARCHIPELAGO_REPO_URL   - git URL of archipelago (default: ssh fallback / local path)
+#   ARCHIPELAGO_REVISION   - branch / tag / commit (default: main)
+#   EVAL_PROJECT_DIR       - GCS prefix for this eval project
+#                            (default: eval-projects/seed-pro-pass3-20260616)
+#   EVAL_BUCKET            - GCS bucket name (default: sotalab-archipelago-eval)
+#   NEW_API_SECRET_NAME    - Secret Manager secret name (default: NEW_API_TOKEN-staging)
+#   NEW_API_BASE           - New API base URL (default: https://new-api-staging.sotalab.ai)
+
+set -euo pipefail
+
+metadata_value() {
+  local key="$1"
+  local default="$2"
+  local value
+  value="$(curl -fsS -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/attributes/${key}" 2>/dev/null || true)"
+  if [[ -n "$value" ]]; then
+    printf '%s' "$value"
+  else
+    printf '%s' "$default"
+  fi
+}
+
+config_value() {
+  local key="$1"
+  local default="$2"
+  local current="${!key:-}"
+  if [[ -n "$current" ]]; then
+    printf '%s' "$current"
+  else
+    metadata_value "$key" "$default"
+  fi
+}
+
+ARCHIPELAGO_REPO_URL="$(config_value ARCHIPELAGO_REPO_URL "https://github.com/SoTALab-ai/archipelago.git")"
+ARCHIPELAGO_REVISION="$(config_value ARCHIPELAGO_REVISION "apex-local-samples")"
+EVAL_PROJECT_DIR="$(config_value EVAL_PROJECT_DIR "eval-projects/seed-pro-pass3-20260616")"
+EVAL_BUCKET="$(config_value EVAL_BUCKET "sotalab-archipelago-eval")"
+NEW_API_SECRET_NAME="$(config_value NEW_API_SECRET_NAME "NEW_API_TOKEN-staging")"
+HF_TOKEN_SECRET_NAME="$(config_value HF_TOKEN_SECRET_NAME "HF_TOKEN")"
+NEW_API_BASE="$(config_value NEW_API_BASE "https://new-api-staging.sotalab.ai/v1")"
+ARCHIPELAGO_DIR="$(config_value ARCHIPELAGO_DIR "/opt/archipelago")"
+ARCHIPELAGO_TGZ_GCS_URI="$(config_value ARCHIPELAGO_TGZ_GCS_URI "")"
+ENV_IMAGE="$(config_value ENV_IMAGE "asia-east1-docker.pkg.dev/sotalab-prod/docker-repo/sotalab-apex-archipelago-environment-prod")"
+ENV_IMAGE_TAG="$(config_value ENV_IMAGE_TAG "latest")"
+WORKER_USER="$(config_value WORKER_USER "lumin")"
+RUN_DYNAMIC_QUEUE="$(config_value RUN_DYNAMIC_QUEUE "0")"
+RUN_LEGACY_PUBSUB="$(config_value RUN_LEGACY_PUBSUB "0")"
+QUEUE_NAME="$(config_value QUEUE_NAME "pass5")"
+ATTEMPT_START="$(config_value ATTEMPT_START "1")"
+ATTEMPT_END="$(config_value ATTEMPT_END "5")"
+EVAL_MODEL="$(config_value EVAL_MODEL "doubao-seed-2-0-pro-260215")"
+TEMPERATURE="$(config_value TEMPERATURE "0.7")"
+MAX_STEPS="$(config_value MAX_STEPS "200")"
+MAX_CONSECUTIVE_FAILURES="$(config_value MAX_CONSECUTIVE_FAILURES "2")"
+JOBS_FILE="$(config_value JOBS_FILE "$ARCHIPELAGO_DIR/state/task_ids.json")"
+TASK_IDS_GCS_URI="$(config_value TASK_IDS_GCS_URI "")"
+
+echo "[setup_worker] starting at $(date -Iseconds)"
+echo "[setup_worker] config: project_dir=$EVAL_PROJECT_DIR bucket=$EVAL_BUCKET dynamic=$RUN_DYNAMIC_QUEUE queue=$QUEUE_NAME attempts=$ATTEMPT_START..$ATTEMPT_END model=$EVAL_MODEL temperature=$TEMPERATURE"
+
+# 1. System packages
+echo "[setup_worker] installing system packages"
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  apt-transport-https ca-certificates curl gnupg lsb-release \
+  python3 python3-pip python3-venv git
+
+# Refresh config after curl is installed. Fresh images may not have curl before
+# the first apt-get, so the initial metadata reads can fall back to defaults.
+ARCHIPELAGO_REPO_URL="$(metadata_value ARCHIPELAGO_REPO_URL "$ARCHIPELAGO_REPO_URL")"
+ARCHIPELAGO_REVISION="$(metadata_value ARCHIPELAGO_REVISION "$ARCHIPELAGO_REVISION")"
+EVAL_PROJECT_DIR="$(metadata_value EVAL_PROJECT_DIR "$EVAL_PROJECT_DIR")"
+EVAL_BUCKET="$(metadata_value EVAL_BUCKET "$EVAL_BUCKET")"
+NEW_API_SECRET_NAME="$(metadata_value NEW_API_SECRET_NAME "$NEW_API_SECRET_NAME")"
+HF_TOKEN_SECRET_NAME="$(metadata_value HF_TOKEN_SECRET_NAME "$HF_TOKEN_SECRET_NAME")"
+NEW_API_BASE="$(metadata_value NEW_API_BASE "$NEW_API_BASE")"
+ARCHIPELAGO_DIR="$(metadata_value ARCHIPELAGO_DIR "$ARCHIPELAGO_DIR")"
+ARCHIPELAGO_TGZ_GCS_URI="$(metadata_value ARCHIPELAGO_TGZ_GCS_URI "$ARCHIPELAGO_TGZ_GCS_URI")"
+ENV_IMAGE="$(metadata_value ENV_IMAGE "$ENV_IMAGE")"
+ENV_IMAGE_TAG="$(metadata_value ENV_IMAGE_TAG "$ENV_IMAGE_TAG")"
+WORKER_USER="$(metadata_value WORKER_USER "$WORKER_USER")"
+RUN_DYNAMIC_QUEUE="$(metadata_value RUN_DYNAMIC_QUEUE "$RUN_DYNAMIC_QUEUE")"
+RUN_LEGACY_PUBSUB="$(metadata_value RUN_LEGACY_PUBSUB "$RUN_LEGACY_PUBSUB")"
+QUEUE_NAME="$(metadata_value QUEUE_NAME "$QUEUE_NAME")"
+ATTEMPT_START="$(metadata_value ATTEMPT_START "$ATTEMPT_START")"
+ATTEMPT_END="$(metadata_value ATTEMPT_END "$ATTEMPT_END")"
+EVAL_MODEL="$(metadata_value EVAL_MODEL "$EVAL_MODEL")"
+TEMPERATURE="$(metadata_value TEMPERATURE "$TEMPERATURE")"
+MAX_STEPS="$(metadata_value MAX_STEPS "$MAX_STEPS")"
+MAX_CONSECUTIVE_FAILURES="$(metadata_value MAX_CONSECUTIVE_FAILURES "$MAX_CONSECUTIVE_FAILURES")"
+JOBS_FILE="$(metadata_value JOBS_FILE "$JOBS_FILE")"
+TASK_IDS_GCS_URI="$(metadata_value TASK_IDS_GCS_URI "$TASK_IDS_GCS_URI")"
+echo "[setup_worker] refreshed config: project_dir=$EVAL_PROJECT_DIR bucket=$EVAL_BUCKET dynamic=$RUN_DYNAMIC_QUEUE queue=$QUEUE_NAME attempts=$ATTEMPT_START..$ATTEMPT_END model=$EVAL_MODEL temperature=$TEMPERATURE"
+
+# Docker (debian-style)
+if ! command -v docker >/dev/null 2>&1; then
+  curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+  sh /tmp/get-docker.sh
+fi
+systemctl enable docker
+systemctl start docker
+
+if ! id "$WORKER_USER" >/dev/null 2>&1; then
+  useradd -m -s /bin/bash "$WORKER_USER"
+fi
+usermod -aG docker "$WORKER_USER" || true
+WORKER_HOME="$(getent passwd "$WORKER_USER" | cut -d: -f6)"
+
+# Pull prebuilt environment image so the worker doesn't need to build it.
+echo "[setup_worker] pulling environment image ${ENV_IMAGE}:${ENV_IMAGE_TAG}"
+gcloud auth configure-docker asia-east1-docker.pkg.dev --quiet || true
+if docker pull "${ENV_IMAGE}:${ENV_IMAGE_TAG}"; then
+  docker tag "${ENV_IMAGE}:${ENV_IMAGE_TAG}" apex-test-environment:latest
+  echo "[setup_worker] tagged ${ENV_IMAGE}:${ENV_IMAGE_TAG} as apex-test-environment:latest"
+else
+  echo "[setup_worker] WARNING: could not pull ${ENV_IMAGE}:${ENV_IMAGE_TAG}; main.py will fall back to docker compose --build"
+fi
+
+# Google Cloud SDK (gsutil)
+if ! command -v gsutil >/dev/null 2>&1; then
+  echo "[setup_worker] installing gsutil"
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    > /etc/apt/sources.list.d/google-cloud-sdk.list
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+  apt-get update -y
+  apt-get install -y --no-install-recommends google-cloud-cli
+fi
+
+# uv (Python package manager)
+if ! command -v uv >/dev/null 2>&1; then
+  echo "[setup_worker] installing uv"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # uv installs into ~/.local/bin. Copy the binary out of /root so workers
+  # running as the login user can execute it.
+  if [[ -x /root/.local/bin/uv ]]; then
+    install -m 0755 /root/.local/bin/uv /usr/local/bin/uv
+  fi
+fi
+
+# 2. Fetch archipelago code from GCS (avoids GitHub auth on fresh VMs)
+echo "[setup_worker] fetching archipelago code from GCS"
+mkdir -p "$ARCHIPELAGO_DIR"
+if [[ -z "$ARCHIPELAGO_TGZ_GCS_URI" ]]; then
+  ARCHIPELAGO_TGZ_GCS_URI="gs://${EVAL_BUCKET}/${EVAL_PROJECT_DIR}/setup/archipelago.tgz"
+fi
+if gsutil cp "$ARCHIPELAGO_TGZ_GCS_URI" /tmp/archipelago.tgz; then
+  rm -rf "$ARCHIPELAGO_DIR"
+  tar xzf /tmp/archipelago.tgz -C /opt
+  echo "[setup_worker] extracted to $ARCHIPELAGO_DIR"
+else
+  echo "[setup_worker] GCS fetch failed; falling back to git clone"
+  if [[ -d "$ARCHIPELAGO_DIR/.git" ]]; then
+    cd "$ARCHIPELAGO_DIR"
+    git fetch --all
+    git checkout "$ARCHIPELAGO_REVISION"
+  else
+    git clone --branch "$ARCHIPELAGO_REVISION" "$ARCHIPELAGO_REPO_URL" "$ARCHIPELAGO_DIR"
+  fi
+fi
+
+# 3. New API token from Secret Manager
+echo "[setup_worker] fetching New API token"
+NEW_API_TOKEN="$(gcloud secrets versions access latest \
+  --project="sotalab-prod" \
+  --secret="$NEW_API_SECRET_NAME")"
+
+# 3b. HuggingFace token (gated dataset mercor/apex-agents)
+echo "[setup_worker] fetching HF token"
+HF_TOKEN_VAL="$(gcloud secrets versions access latest \
+  --project="sotalab-prod" \
+  --secret="$HF_TOKEN_SECRET_NAME" 2>/dev/null || true)"
+if [[ -n "$HF_TOKEN_VAL" ]]; then
+  mkdir -p /root/.cache/huggingface
+  echo -n "$HF_TOKEN_VAL" > /root/.cache/huggingface/token
+  chmod 600 /root/.cache/huggingface/token
+  if [[ -n "$WORKER_HOME" ]]; then
+    mkdir -p "$WORKER_HOME/.cache/huggingface"
+    echo -n "$HF_TOKEN_VAL" > "$WORKER_HOME/.cache/huggingface/token"
+    chown -R "$WORKER_USER:$WORKER_USER" "$WORKER_HOME/.cache"
+    chmod 600 "$WORKER_HOME/.cache/huggingface/token"
+  fi
+  # Also expose for uv run
+  export HF_TOKEN="$HF_TOKEN_VAL"
+  echo "[setup_worker] HF_TOKEN written to local HuggingFace token files"
+fi
+
+cat > "$ARCHIPELAGO_DIR/agents/.env" <<EOF
+ENV=local
+AGENT_TIMEOUT_SECONDS=81000
+LITELLM_PROXY_API_BASE=$NEW_API_BASE
+LITELLM_PROXY_API_KEY=$NEW_API_TOKEN
+EOF
+
+# 4. Install deps
+echo "[setup_worker] uv sync in agents/"
+chown -R "$WORKER_USER:$WORKER_USER" "$ARCHIPELAGO_DIR"
+sudo -u "$WORKER_USER" env PATH="/usr/local/bin:$PATH" bash -lc "cd '$ARCHIPELAGO_DIR/agents' && uv sync --locked"
+
+echo "[setup_worker] uv sync in grading/"
+sudo -u "$WORKER_USER" env PATH="/usr/local/bin:$PATH" bash -lc "cd '$ARCHIPELAGO_DIR/grading' && uv sync --locked"
+
+chown -R "$WORKER_USER:$WORKER_USER" "$ARCHIPELAGO_DIR"
+
+if [[ -n "$TASK_IDS_GCS_URI" ]]; then
+  echo "[setup_worker] fetching task ids from $TASK_IDS_GCS_URI"
+  mkdir -p "$(dirname "$JOBS_FILE")"
+  gsutil cp "$TASK_IDS_GCS_URI" "$JOBS_FILE"
+  chown -R "$WORKER_USER:$WORKER_USER" "$(dirname "$JOBS_FILE")"
+fi
+
+# 5. Worker environment file (read by eval_worker.py and systemd unit)
+cat > /etc/archipelago-eval.env <<EOF
+ARCHIPELAGO_DIR=$ARCHIPELAGO_DIR
+EVAL_PROJECT_DIR=$EVAL_PROJECT_DIR
+EVAL_BUCKET=$EVAL_BUCKET
+EOF
+
+# 6. Python GCS client (system-wide so systemd doesn't depend on uv venv)
+pip3 install --break-system-packages -q \
+  google-cloud-storage
+
+if [[ "$RUN_DYNAMIC_QUEUE" == "1" ]]; then
+  cat > /etc/systemd/system/archipelago-queue-worker.service <<UNIT
+[Unit]
+Description=Archipelago eval worker (dynamic GCS queue)
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=$WORKER_USER
+WorkingDirectory=$ARCHIPELAGO_DIR
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=/etc/archipelago-eval.env
+ExecStart=/usr/bin/python3 $ARCHIPELAGO_DIR/scripts/worker_queue.py --jobs-file $JOBS_FILE --project-dir $EVAL_PROJECT_DIR --bucket $EVAL_BUCKET --queue-name $QUEUE_NAME --attempt-start $ATTEMPT_START --attempt-end $ATTEMPT_END --model $EVAL_MODEL --temperature $TEMPERATURE --max-steps $MAX_STEPS --shuffle --max-consecutive-failures $MAX_CONSECUTIVE_FAILURES
+Restart=on-failure
+RestartSec=30
+StandardOutput=append:/var/log/archipelago-queue-worker.log
+StandardError=append:/var/log/archipelago-queue-worker.log
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+  systemctl daemon-reload
+  systemctl enable archipelago-queue-worker.service
+  systemctl restart archipelago-queue-worker.service
+  echo "[setup_worker] dynamic queue worker service started"
+elif [[ "$RUN_LEGACY_PUBSUB" == "1" ]]; then
+  # 7. Legacy Pub/Sub worker service. Kept for manual recovery only; the normal
+  # eval path uses the GCS queue above.
+  PUBSUB_SUBSCRIPTION="$(metadata_value PUBSUB_SUBSCRIPTION "archipelago-eval-workers")"
+  PUBSUB_PROJECT="$(metadata_value PUBSUB_PROJECT "sotalab-prod")"
+  cat >> /etc/archipelago-eval.env <<EOF
+PUBSUB_SUBSCRIPTION=$PUBSUB_SUBSCRIPTION
+PUBSUB_PROJECT=$PUBSUB_PROJECT
+EOF
+  pip3 install --break-system-packages -q google-cloud-pubsub
+  cat > /etc/systemd/system/archipelago-eval-worker.service <<'UNIT'
+[Unit]
+Description=Archipelago eval worker (Pub/Sub subscriber)
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/archipelago-eval.env
+ExecStart=/usr/bin/python3 /opt/archipelago/scripts/eval_worker.py
+Restart=always
+RestartSec=5
+StandardOutput=append:/var/log/archipelago-eval-worker.log
+StandardError=append:/var/log/archipelago-eval-worker.log
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+  systemctl daemon-reload
+  systemctl enable archipelago-eval-worker.service
+  systemctl restart archipelago-eval-worker.service
+
+  echo "[setup_worker] worker service started"
+else
+  echo "[setup_worker] no worker service started; use RUN_DYNAMIC_QUEUE=1 for GCS queue workers or launch worker_static.py manually"
+fi
+echo "[setup_worker] done at $(date -Iseconds)"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Quick smoke test for the archipelago eval stack.
+# Verifies (in order):
+#   1. New API token can be fetched from Secret Manager
+#   2. New API responds to a simple chat completion (model exists)
+#   3. HuggingFace token is valid + can read gated dataset mercor/apex-agents
+#   4. litellm via New API proxy mode works for the target model
+#
+# Usage:
+#   ./scripts/smoke_test.sh [model_id ...]
+#   defaults to: doubao-seed-2-0-pro-260215 (then qwen3.6-27b)
+
+set -uo pipefail
+
+PROJECT="${PROJECT:-sotalab-staging}"
+SECRET="${SECRET:-NEW_API_TOKEN-staging}"
+HF_PROJECT="${HF_PROJECT:-sotalab-prod}"
+HF_SECRET="${HF_SECRET:-HF_TOKEN}"
+BASE="${BASE:-https://new-api-staging.sotalab.ai/v1}"
+
+MODELS=("$@")
+[[ ${#MODELS[@]} -eq 0 ]] && MODELS=("doubao-seed-2-0-pro-260215" "qwen3.6-27b")
+
+fail=0
+trap 'echo; [[ $fail -gt 0 ]] && echo "SMOKE TEST FAILED ($fail failures)" || echo "SMOKE TEST PASSED"' EXIT
+
+echo "============================================================"
+echo " Archipelago eval smoke test"
+echo "============================================================"
+
+# 1) New API token
+echo "[1/4] fetch New API token"
+NEW_API_TOKEN="$(gcloud secrets versions access latest \
+  --project="$PROJECT" --secret="$SECRET" 2>/dev/null || true)"
+if [[ -z "$NEW_API_TOKEN" ]]; then
+  echo "  FAIL: cannot read secret $SECRET from $PROJECT"
+  fail=$((fail+1))
+else
+  echo "  OK (token len=${#NEW_API_TOKEN})"
+fi
+
+# 2) New API responds
+echo "[2/4] New API responds to /v1/models"
+HTTP=$(curl -sS -o /tmp/_models.json -w "%{http_code}" \
+  -H "Authorization: Bearer $NEW_API_TOKEN" \
+  "$BASE/models" 2>/dev/null || echo "000")
+if [[ "$HTTP" == "200" ]]; then
+  N=$(python3 -c "import json; d=json.load(open('/tmp/_models.json')); print(len(d.get('data', [])))" 2>/dev/null)
+  echo "  OK ($N models available)"
+else
+  echo "  FAIL: HTTP $HTTP"
+  fail=$((fail+1))
+fi
+
+# 3) HuggingFace token
+echo "[3/4] HuggingFace token (gated dataset mercor/apex-agents)"
+HF_TOKEN="$(gcloud secrets versions access latest \
+  --project="$HF_PROJECT" --secret="$HF_SECRET" 2>/dev/null || true)"
+if [[ -z "$HF_TOKEN" ]]; then
+  echo "  FAIL: cannot read secret $HF_SECRET from $HF_PROJECT"
+  fail=$((fail+1))
+else
+  HTTP=$(curl -sS -o /tmp/_hf.json -w "%{http_code}" \
+    -H "Authorization: Bearer $HF_TOKEN" \
+    "https://huggingface.co/api/datasets/mercor/apex-agents" 2>/dev/null || echo "000")
+  if [[ "$HTTP" == "200" ]]; then
+    GATED=$(python3 -c "import json; d=json.load(open('/tmp/_hf.json')); print(d.get('gated','no'))" 2>/dev/null)
+    echo "  OK (gated=$GATED, token grants access)"
+  else
+    echo "  FAIL: HTTP $HTTP (token rejected or token missing scope)"
+    fail=$((fail+1))
+  fi
+fi
+
+# 4) litellm proxy mode against each model
+echo "[4/4] litellm proxy -> New API -> each model"
+for m in "${MODELS[@]}"; do
+  RESP=$(curl -sS -X POST "$BASE/chat/completions" \
+    -H "Authorization: Bearer $NEW_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -w '\n__HTTP__:%{http_code}\n__T__:%{time_total}\n' \
+    -d "{\"model\":\"$m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with one word: ok\"}],\"max_tokens\":15}" \
+    2>/dev/null)
+  HTTP=$(echo "$RESP" | grep '__HTTP__' | cut -d: -f2)
+  T=$(echo "$RESP" | grep '__T__' | cut -d: -f2)
+  if [[ "$HTTP" == "200" ]]; then
+    CONTENT=$(echo "$RESP" | sed '/^__/d' | python3 -c "
+import sys, json
+try:
+    d=json.load(sys.stdin)
+    print(d['choices'][0]['message']['content'][:40])
+except: print('<parse err>')
+" 2>/dev/null)
+    printf "  OK   %-30s time=%4.2fs  reply=%-20s\n" "$m" "$T" "\"$CONTENT\""
+  else
+    printf "  FAIL %-30s HTTP=%s\n" "$m" "$HTTP"
+    fail=$((fail+1))
+  fi
+done
+
+# cleanup tmp
+rm -f /tmp/_models.json /tmp/_hf.json

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tear down all GCP resources created for the archipelago eval.
+# Usage: ./scripts/teardown.sh <project> <zone> <bucket> <worker_count>
+#
+# Args default to the values used in the 2026-06-16 seed-pro-pass3 run.
+
+set -uo pipefail
+
+PROJECT="${1:-sotalab-prod}"
+ZONE="${2:-asia-east1-b}"
+BUCKET="${3:-sotalab-archipelago-eval}"
+WORKER_COUNT="${4:-5}"
+
+CONFIRM="${CONFIRM:-no}"
+if [[ "${CONFIRM}" != "yes" ]]; then
+  cat <<EOF
+============================================================
+TEARDOWN (preview, nothing destroyed)
+============================================================
+  project     : ${PROJECT}
+  zone        : ${ZONE}
+  bucket      : gs://${BUCKET}
+  workers     : ${WORKER_COUNT}
+
+To actually run, set CONFIRM=yes:
+  CONFIRM=yes $0 $*
+
+Or via Makefile:
+  make teardown CONFIRM=yes
+============================================================
+EOF
+  exit 0
+fi
+
+echo "[teardown] deleting ${WORKER_COUNT} VMs"
+for i in $(seq 1 "${WORKER_COUNT}"); do
+  name="archipelago-eval-worker-${i}"
+  echo "  - $name"
+  gcloud compute instances delete "$name" \
+    --project="${PROJECT}" --zone="${ZONE}" --quiet 2>&1 | tail -1
+done
+
+echo "[teardown] emptying + deleting GCS bucket"
+gsutil -m rm -r "gs://${BUCKET}/**" 2>&1 | tail -1 || true
+gcloud storage buckets delete "gs://${BUCKET}" --project="${PROJECT}" --quiet 2>&1 | tail -1
+
+echo "[teardown] done."

--- a/scripts/worker_healthcheck.py
+++ b/scripts/worker_healthcheck.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Batch healthcheck for dynamic archipelago workers.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def run(cmd: list[str], *, timeout: int | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
+
+
+def list_instances(project: str, prefix: str) -> list[dict[str, Any]]:
+    proc = run(
+        [
+            "gcloud",
+            "compute",
+            "instances",
+            "list",
+            f"--project={project}",
+            f"--filter=name~^{prefix}-",
+            "--format=json(name,zone,status)",
+        ]
+    )
+    if proc.returncode != 0:
+        raise SystemExit(proc.stderr.strip())
+    return json.loads(proc.stdout or "[]")
+
+
+def zone_name(zone_url: str) -> str:
+    return zone_url.rsplit("/", 1)[-1]
+
+
+def check_one(project: str, instance: dict[str, Any], timeout: int) -> dict[str, str]:
+    name = instance["name"]
+    zone = zone_name(instance["zone"])
+    status = instance.get("status", "")
+    if status != "RUNNING":
+        return {
+            "name": name,
+            "zone": zone,
+            "vm": status,
+            "service": "-",
+            "pid": "-",
+            "last": "-",
+        }
+
+    remote = (
+        "svc=$(systemctl is-active archipelago-queue-worker.service 2>/dev/null || true); "
+        "pid=$(pgrep -af 'worker_queue.py' | head -1 | awk '{print $1}' || true); "
+        "last=$(tail -n 1 /var/log/archipelago-queue-worker.log 2>/dev/null | tr '\\t' ' ' || true); "
+        "printf 'service=%s\\npid=%s\\nlast=%s\\n' \"$svc\" \"$pid\" \"$last\""
+    )
+    proc = run(
+        [
+            "gcloud",
+            "compute",
+            "ssh",
+            name,
+            f"--project={project}",
+            f"--zone={zone}",
+            "--command",
+            remote,
+            "--quiet",
+        ],
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        return {
+            "name": name,
+            "zone": zone,
+            "vm": status,
+            "service": "ssh-failed",
+            "pid": "-",
+            "last": proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else "-",
+        }
+
+    fields = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            fields[key] = value
+    return {
+        "name": name,
+        "zone": zone,
+        "vm": status,
+        "service": fields.get("service", "-") or "-",
+        "pid": fields.get("pid", "-") or "-",
+        "last": fields.get("last", "-") or "-",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check dynamic worker health")
+    parser.add_argument("--project", default="sotalab-prod")
+    parser.add_argument("--worker-prefix", default="archipelago-eval-auto")
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--jobs", type=int, default=8)
+    args = parser.parse_args()
+
+    instances = list_instances(args.project, args.worker_prefix)
+    instances.sort(key=lambda item: item["name"])
+    if not instances:
+        print("no instances found")
+        return 1
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
+        rows = list(
+            executor.map(
+                lambda item: check_one(args.project, item, args.timeout),
+                instances,
+            )
+        )
+
+    print(f"{'name':32} {'zone':15} {'vm':12} {'service':12} {'pid':8} last")
+    bad = 0
+    for row in rows:
+        if row["vm"] != "RUNNING" or row["service"] != "active" or row["pid"] == "-":
+            bad += 1
+        last = row["last"]
+        if len(last) > 100:
+            last = last[-100:]
+        print(
+            f"{row['name'][:32]:32} {row['zone'][:15]:15} {row['vm'][:12]:12} "
+            f"{row['service'][:12]:12} {row['pid'][:8]:8} {last}"
+        )
+    return 0 if bad == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/worker_queue.py
+++ b/scripts/worker_queue.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Dynamic GCS-backed queue worker for APEX evaluations.
+
+Each job is a (task_id, attempt) pair. Workers atomically claim jobs by creating
+state/claims/<queue>/<job_id>.json with if_generation_match=0, then run
+run_single_task.py. Completed GCS results are always skipped first, so the queue
+can be restarted or expanded safely.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from google.api_core.exceptions import NotFound, PreconditionFailed
+from google.cloud import storage
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger(f"worker_queue.{socket.gethostname()}")
+
+ARCHIPELAGO_DIR = Path(os.environ.get("ARCHIPELAGO_DIR", "/opt/archipelago"))
+WORKER_ID = socket.gethostname()
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_jobs(path: Path, attempt_start: int, attempt_end: int) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text())
+    jobs: list[dict[str, Any]] = []
+    for item in data:
+        task_id = item["task_id"] if isinstance(item, dict) else str(item)
+        model = item.get("model") if isinstance(item, dict) else None
+        for attempt in range(attempt_start, attempt_end + 1):
+            jobs.append(
+                {
+                    "task_id": task_id,
+                    "attempt": attempt,
+                    "model": model,
+                    "job_id": f"{task_id}-a{attempt}",
+                }
+            )
+    return jobs
+
+
+def result_prefix(project_dir: str, task_id: str, attempt: int) -> str:
+    return f"{project_dir}/results/{task_id}/attempt{attempt}"
+
+
+def has_completed_result(bucket: storage.Bucket, project_dir: str, task_id: str, attempt: int) -> bool:
+    prefix = result_prefix(project_dir, task_id, attempt)
+    status_blob = bucket.blob(f"{prefix}/status.tsv")
+    try:
+        status = status_blob.download_as_text()
+    except Exception:
+        return False
+    if "run_status\tcompleted" not in status:
+        return False
+    return bucket.blob(f"{prefix}/grades.json").exists() and bucket.blob(
+        f"{prefix}/trajectory.json"
+    ).exists()
+
+
+def claim_job(
+    bucket: storage.Bucket,
+    project_dir: str,
+    queue_name: str,
+    job: dict[str, Any],
+) -> bool:
+    blob = bucket.blob(f"{project_dir}/state/claims/{queue_name}/{job['job_id']}.json")
+    payload = {
+        **job,
+        "worker_id": WORKER_ID,
+        "claimed_at": now_iso(),
+    }
+    try:
+        blob.upload_from_string(
+            json.dumps(payload, indent=2) + "\n",
+            content_type="application/json",
+            if_generation_match=0,
+        )
+        return True
+    except PreconditionFailed:
+        return False
+
+
+def mark_done(
+    bucket: storage.Bucket,
+    project_dir: str,
+    queue_name: str,
+    job: dict[str, Any],
+    rc: int,
+) -> None:
+    blob = bucket.blob(f"{project_dir}/state/done/{queue_name}/{job['job_id']}.json")
+    payload = {
+        **job,
+        "worker_id": WORKER_ID,
+        "finished_at": now_iso(),
+        "returncode": rc,
+    }
+    blob.upload_from_string(json.dumps(payload, indent=2) + "\n", content_type="application/json")
+
+
+def mark_failure(
+    bucket: storage.Bucket,
+    project_dir: str,
+    queue_name: str,
+    job: dict[str, Any],
+    rc: int,
+) -> None:
+    blob = bucket.blob(
+        f"{project_dir}/state/failures/{queue_name}/{job['job_id']}-{WORKER_ID}-{int(time.time())}.json"
+    )
+    payload = {
+        **job,
+        "worker_id": WORKER_ID,
+        "finished_at": now_iso(),
+        "returncode": rc,
+    }
+    blob.upload_from_string(json.dumps(payload, indent=2) + "\n", content_type="application/json")
+
+
+def release_claim(
+    bucket: storage.Bucket,
+    project_dir: str,
+    queue_name: str,
+    job: dict[str, Any],
+) -> None:
+    blob = bucket.blob(f"{project_dir}/state/claims/{queue_name}/{job['job_id']}.json")
+    try:
+        blob.delete()
+    except NotFound:
+        return
+
+
+def run_job(
+    job: dict[str, Any],
+    model: str,
+    bucket_name: str,
+    project_dir: str,
+    max_steps: int,
+    temperature: float | None,
+) -> int:
+    cmd = [
+        "python3",
+        str(ARCHIPELAGO_DIR / "scripts" / "run_single_task.py"),
+        "--task-id",
+        job["task_id"],
+        "--model",
+        model,
+        "--attempt",
+        str(job["attempt"]),
+        "--worker-id",
+        WORKER_ID,
+        "--eval-project",
+        project_dir,
+        "--bucket",
+        bucket_name,
+        "--project-dir",
+        project_dir,
+        "--max-steps",
+        str(max_steps),
+    ]
+    if temperature is not None:
+        cmd.extend(["--temperature", str(temperature)])
+    log.info("running job_id=%s task=%s attempt=%s", job["job_id"], job["task_id"], job["attempt"])
+    return subprocess.run(cmd, cwd=ARCHIPELAGO_DIR).returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run dynamic GCS queue jobs")
+    parser.add_argument("--jobs-file", required=True)
+    parser.add_argument("--project-dir", required=True)
+    parser.add_argument("--bucket", default=os.environ.get("EVAL_BUCKET", "sotalab-archipelago-eval"))
+    parser.add_argument("--queue-name", default="pass5")
+    parser.add_argument("--attempt-start", type=int, default=1)
+    parser.add_argument("--attempt-end", type=int, default=5)
+    parser.add_argument("--model", default="doubao-seed-2-0-pro-260215")
+    parser.add_argument("--max-steps", type=int, default=200)
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--idle-sleep", type=float, default=10.0)
+    parser.add_argument("--max-consecutive-failures", type=int, default=2)
+    parser.add_argument("--shuffle", action="store_true")
+    args = parser.parse_args()
+
+    client = storage.Client()
+    bucket = client.bucket(args.bucket)
+    jobs = load_jobs(Path(args.jobs_file), args.attempt_start, args.attempt_end)
+    if args.shuffle:
+        random.shuffle(jobs)
+
+    log.info(
+        "queue starting: worker_id=%s queue=%s jobs=%d attempts=%d..%d model=%s temperature=%s project_dir=%s",
+        WORKER_ID,
+        args.queue_name,
+        len(jobs),
+        args.attempt_start,
+        args.attempt_end,
+        args.model,
+        args.temperature,
+        args.project_dir,
+    )
+
+    completed = skipped_claimed = claimed = failures = consecutive_failures = 0
+    for job in jobs:
+        if has_completed_result(bucket, args.project_dir, job["task_id"], job["attempt"]):
+            completed += 1
+            continue
+        if not claim_job(bucket, args.project_dir, args.queue_name, job):
+            skipped_claimed += 1
+            continue
+        claimed += 1
+        rc = run_job(
+            job=job,
+            model=args.model,
+            bucket_name=args.bucket,
+            project_dir=args.project_dir,
+            max_steps=args.max_steps,
+            temperature=args.temperature,
+        )
+        if rc != 0:
+            failures += 1
+            consecutive_failures += 1
+            mark_failure(bucket, args.project_dir, args.queue_name, job, rc)
+            release_claim(bucket, args.project_dir, args.queue_name, job)
+            log.warning("job failed: job_id=%s rc=%d", job["job_id"], rc)
+            if consecutive_failures >= args.max_consecutive_failures:
+                log.error(
+                    "stopping after %d consecutive failures; last job_id=%s",
+                    consecutive_failures,
+                    job["job_id"],
+                )
+                return 1
+        else:
+            consecutive_failures = 0
+            mark_done(bucket, args.project_dir, args.queue_name, job, rc)
+            release_claim(bucket, args.project_dir, args.queue_name, job)
+        time.sleep(args.idle_sleep)
+
+    log.info(
+        "queue done: completed=%d skipped_claimed=%d claimed=%d failures=%d",
+        completed,
+        skipped_claimed,
+        claimed,
+        failures,
+    )
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/worker_shard.py
+++ b/scripts/worker_shard.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Run a static shard of HuggingFace APEX tasks on one worker VM.
+
+Each worker gets a deterministic modulo shard of the full task list. Tasks run
+serially inside one VM so port 8080, Docker container state, and local output do
+not overlap between tasks. Different VMs write to different task prefixes in
+GCS.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger(f"worker_shard.{socket.gethostname()}")
+
+ARCHIPELAGO_DIR = Path(os.environ.get("ARCHIPELAGO_DIR", "/opt/archipelago"))
+DEFAULT_BUCKET = os.environ.get("EVAL_BUCKET", "sotalab-archipelago-eval")
+DEFAULT_PROJECT_DIR = os.environ.get(
+    "EVAL_PROJECT_DIR", "eval-projects/seed-pro-full-20260618"
+)
+WORKER_ID = socket.gethostname()
+
+
+def load_task_ids(path: Path) -> list[str]:
+    data = json.loads(path.read_text())
+    task_ids: list[str] = []
+    for item in data:
+        if isinstance(item, str):
+            task_ids.append(item)
+        elif isinstance(item, dict) and item.get("task_id"):
+            task_ids.append(str(item["task_id"]))
+        else:
+            raise ValueError(f"Unsupported task entry: {item!r}")
+    if len(task_ids) != len(set(task_ids)):
+        raise ValueError("Task list contains duplicate task_id values")
+    return task_ids
+
+
+def gcs_has_completed_result(bucket: str, project_dir: str, task_id: str, attempt: int) -> bool:
+    prefix = f"gs://{bucket}/{project_dir}/results/{task_id}/attempt{attempt}"
+    status = subprocess.run(
+        ["gsutil", "cat", f"{prefix}/status.tsv"],
+        text=True,
+        capture_output=True,
+    )
+    if status.returncode != 0 or "run_status\tcompleted" not in status.stdout:
+        return False
+
+    listing = subprocess.run(
+        ["gsutil", "ls", "-r", f"{prefix}/**"],
+        text=True,
+        capture_output=True,
+    )
+    if listing.returncode != 0:
+        return False
+    files = listing.stdout.splitlines()
+    return any(p.endswith("/trajectory.json") for p in files) and any(
+        p.endswith("/grades.json") for p in files
+    )
+
+
+def run_task(
+    task_id: str,
+    model: str,
+    attempt: int,
+    bucket: str,
+    project_dir: str,
+    max_steps: int,
+    temperature: float | None,
+    rerun: bool,
+) -> int:
+    cmd = [
+        "python3",
+        str(ARCHIPELAGO_DIR / "scripts" / "run_single_task.py"),
+        "--task-id",
+        task_id,
+        "--model",
+        model,
+        "--attempt",
+        str(attempt),
+        "--worker-id",
+        WORKER_ID,
+        "--eval-project",
+        project_dir,
+        "--bucket",
+        bucket,
+        "--project-dir",
+        project_dir,
+        "--max-steps",
+        str(max_steps),
+    ]
+    if temperature is not None:
+        cmd.extend(["--temperature", str(temperature)])
+    if rerun:
+        cmd.append("--rerun")
+    log.info("running task=%s attempt=%d", task_id, attempt)
+    return subprocess.run(cmd, cwd=ARCHIPELAGO_DIR).returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one static shard of APEX tasks")
+    parser.add_argument("--tasks-file", required=True)
+    parser.add_argument("--shard-index", type=int, required=True, help="0-based shard index")
+    parser.add_argument("--num-shards", type=int, default=5)
+    parser.add_argument("--attempt", type=int, default=1)
+    parser.add_argument(
+        "--attempt-start",
+        type=int,
+        default=None,
+        help="First attempt to run when --k is set; defaults to --attempt",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=1,
+        help="Number of sequential attempts to run per task",
+    )
+    parser.add_argument("--model", default="doubao-seed-2-0-pro-260215")
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--project-dir", default=DEFAULT_PROJECT_DIR)
+    parser.add_argument("--max-steps", type=int, default=200)
+    parser.add_argument("--temperature", type=float, default=None)
+    parser.add_argument("--force", action="store_true", help="Rerun even if GCS already has completed output")
+    parser.add_argument("--sleep-between", type=float, default=2.0)
+    args = parser.parse_args()
+
+    if args.shard_index < 0 or args.shard_index >= args.num_shards:
+        raise SystemExit("--shard-index must be in [0, num-shards)")
+
+    task_ids = load_task_ids(Path(args.tasks_file))
+    shard_tasks = [
+        task_id for i, task_id in enumerate(task_ids) if i % args.num_shards == args.shard_index
+    ]
+    if args.k < 1:
+        raise SystemExit("--k must be >= 1")
+    attempt_start = args.attempt if args.attempt_start is None else args.attempt_start
+    if attempt_start < 1:
+        raise SystemExit("--attempt-start/--attempt must be >= 1")
+    attempts = list(range(attempt_start, attempt_start + args.k))
+
+    log.info(
+        "shard starting: worker_id=%s shard=%d/%d tasks=%d total=%d attempts=%s model=%s temperature=%s project_dir=%s",
+        WORKER_ID,
+        args.shard_index,
+        args.num_shards,
+        len(shard_tasks),
+        len(task_ids),
+        ",".join(str(a) for a in attempts),
+        args.model,
+        args.temperature,
+        args.project_dir,
+    )
+
+    failures = 0
+    skipped = 0
+    started_at = time.time()
+    for ordinal, task_id in enumerate(shard_tasks, start=1):
+        log.info("task %d/%d: %s", ordinal, len(shard_tasks), task_id)
+        for attempt in attempts:
+            if not args.force and gcs_has_completed_result(
+                args.bucket, args.project_dir, task_id, attempt
+            ):
+                skipped += 1
+                log.info("skip completed task=%s attempt=%d", task_id, attempt)
+                continue
+
+            rc = run_task(
+                task_id=task_id,
+                model=args.model,
+                attempt=attempt,
+                bucket=args.bucket,
+                project_dir=args.project_dir,
+                max_steps=args.max_steps,
+                temperature=args.temperature,
+                rerun=args.force,
+            )
+            if rc != 0:
+                failures += 1
+                log.warning("task failed: task=%s attempt=%d rc=%d", task_id, attempt, rc)
+            time.sleep(args.sleep_between)
+
+    elapsed = time.time() - started_at
+    log.info(
+        "shard done: worker_id=%s shard=%d/%d tasks=%d attempts=%d skipped=%d failures=%d elapsed_sec=%.1f",
+        WORKER_ID,
+        args.shard_index,
+        args.num_shards,
+        len(shard_tasks),
+        len(attempts),
+        skipped,
+        failures,
+        elapsed,
+    )
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/worker_static.py
+++ b/scripts/worker_static.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Static-assignment eval worker — alternative to Pub/Sub.
+
+Each VM runs this script with --task-id T --k K. It:
+  1. Reads /etc/archipelago-eval.env for config
+  2. For each attempt 1..K, runs scripts/run_single_task.py
+  3. Uploads results to GCS (handled by run_single_task.py)
+
+No Pub/Sub, no flow control — each worker is assigned exactly one task.
+
+Usage:
+  python3 scripts/worker_static.py --task-id <task_id> --k 3 [--model doubao-seed-2-0-pro-260215]
+
+This is meant to run via nohup inside each VM, after the VM's setup_worker.sh
+has provisioned the environment image + tokens.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger(f"worker_static.{socket.gethostname()}")
+
+ARCHIPELAGO_DIR = Path(os.environ.get("ARCHIPELAGO_DIR", "/opt/archipelago"))
+EVAL_PROJECT_DIR = os.environ.get("EVAL_PROJECT_DIR", "eval-projects/seed-pro-pass3-20260616")
+EVAL_BUCKET = os.environ.get("EVAL_BUCKET", "sotalab-archipelago-eval")
+
+WORKER_ID = socket.gethostname()
+
+
+def run_one_attempt(task_id: str, model: str, attempt: int, force: bool = False) -> int:
+    cmd = [
+        "python3",
+        str(ARCHIPELAGO_DIR / "scripts" / "run_single_task.py"),
+        "--task-id", task_id,
+        "--model", model,
+        "--attempt", str(attempt),
+        "--worker-id", WORKER_ID,
+        "--eval-project", EVAL_PROJECT_DIR,
+        "--bucket", EVAL_BUCKET,
+        "--project-dir", EVAL_PROJECT_DIR,
+    ]
+    if force:
+        cmd.append("--rerun")
+    log.info("running: %s", " ".join(cmd))
+    return subprocess.run(cmd, cwd=ARCHIPELAGO_DIR).returncode
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--task-id", required=True)
+    ap.add_argument("--k", type=int, default=3)
+    ap.add_argument("--model", default="doubao-seed-2-0-pro-260215")
+    ap.add_argument("--force", action="store_true")
+    args = ap.parse_args()
+
+    log.info(
+        "static worker starting: task_id=%s k=%d model=%s force=%s worker_id=%s",
+        args.task_id, args.k, args.model, args.force, WORKER_ID,
+    )
+
+    for attempt in range(1, args.k + 1):
+        log.info("attempt %d / %d", attempt, args.k)
+        rc = run_one_attempt(args.task_id, args.model, attempt, force=args.force)
+        log.info("attempt %d done rc=%d", attempt, rc)
+        if rc != 0:
+            log.warning("attempt %d failed rc=%d, continuing", attempt, rc)
+
+    log.info("static worker done: task_id=%s", args.task_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- switch the eval scheduler path from Pub/Sub publishing to GCS-backed queue state
- add Makefile and worker scripts for provisioning, dynamic GCS queue workers, monitoring, aggregation, and teardown
- keep the old Pub/Sub subscriber behind an explicit legacy startup flag and ignore local eval artifacts

## Verification
- python3 -m py_compile scripts/*.py
- python3 scripts/local_scheduler.py --help
- python3 scripts/local_scheduler.py publish --help
- make -n provision EVAL_PROJECT=test-eval WORKER_COUNT=1
- make -n publish EVAL_PROJECT=test-eval N_TASKS=1 K=1 MODEL=test-model
- make -n dynamic-workers EVAL_PROJECT=test-eval TARGET_RUNNING=1 MAX_RUNNING=1
- make -n teardown EVAL_PROJECT=test-eval WORKER_COUNT=1