### PR TITLE
Add strict-provider compatibility handling

### DIFF
--- a/agents/runner/agents/react_toolbelt_agent/main.py
+++ b/agents/runner/agents/react_toolbelt_agent/main.py
@@ -67,7 +67,7 @@ class ReActAgent:
         config = run_input.agent_config_values
         self.timeout: int = config.get("timeout", 10800)
         self.max_steps: int = config.get("max_steps", 250)
-        self.tool_call_timeout: int = 60
+        self.tool_call_timeout: int = config.get("tool_call_timeout", 60)
         self.llm_response_timeout: int = config.get("llm_response_timeout", 600)
         self.max_toolbelt_size: int = 80
 

--- a/agents/runner/utils/llm.py
+++ b/agents/runner/utils/llm.py
@@ -2,7 +2,7 @@
 
 import time
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
 import litellm
 from litellm import acompletion, aresponses
@@ -464,6 +464,50 @@ def _with_cached_last_message(
 
 
 _ANTHROPIC_EMPTY_TEXT_PLACEHOLDER = "[empty]"
+_UNSUPPORTED_OPENAI_MESSAGE_FIELDS = frozenset(
+    {"provider_specific_fields", "reasoning_content", "refusal"}
+)
+
+
+def _strip_unsupported_openai_message_fields(value: Any) -> Any:
+    """Return LiteLLM messages safe for strict OpenAI-compatible endpoints."""
+    if isinstance(value, Message):
+        value = value.model_dump(exclude_none=True)
+    if isinstance(value, list | tuple):
+        return [_strip_unsupported_openai_message_fields(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _strip_unsupported_openai_message_fields(item)
+            for key, item in value.items()
+            if key not in _UNSUPPORTED_OPENAI_MESSAGE_FIELDS and item is not None
+        }
+    return value
+
+
+def _strip_invalid_required_schema_fields(value: Any) -> Any:
+    """Remove JSON-schema requirements that strict providers reject."""
+    if isinstance(value, list | tuple):
+        return [_strip_invalid_required_schema_fields(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    sanitized = {
+        key: _strip_invalid_required_schema_fields(item)
+        for key, item in value.items()
+    }
+    required = sanitized.get("required")
+    if not isinstance(required, list | tuple):
+        return sanitized
+
+    properties = sanitized.get("properties")
+    if not isinstance(properties, dict):
+        sanitized.pop("required")
+        return sanitized
+
+    sanitized["required"] = [
+        item for item in required if isinstance(item, str) and item in properties
+    ]
+    return sanitized
 
 
 def normalize_assistant_tool_call_content(
@@ -732,6 +776,10 @@ async def generate_response(
         # content with a non-whitespace placeholder so e.g. an empty
         # alternating-role placeholder message does not fail the whole run.
         messages = _with_nonempty_text_content(messages)
+    messages = cast(
+        list[LitellmAnyMessage],
+        _strip_unsupported_openai_message_fields(messages),
+    )
     cached_messages = _with_cached_last_message(
         _with_cached_system_prompt(messages, model), model
     )
@@ -747,7 +795,11 @@ async def generate_response(
     }
 
     if tools:
-        kwargs["tools"] = _with_cached_tools(tools, model)
+        sanitized_tools = cast(
+            list[ChatCompletionToolParam],
+            _strip_invalid_required_schema_fields(tools),
+        )
+        kwargs["tools"] = _with_cached_tools(sanitized_tools, model)
 
     # If LiteLLM proxy is configured, route completions through it and add tags.
     # Mirrors call_responses_api: rely on explicit api_base/api_key — some SDK /

--- a/agents/tests/test_openai_compat.py
+++ b/agents/tests/test_openai_compat.py
@@ -1,0 +1,40 @@
+from litellm.types.utils import Message
+
+from runner.utils.llm import (
+    _strip_invalid_required_schema_fields,
+    _strip_unsupported_openai_message_fields,
+)
+
+
+def test_strip_unsupported_openai_message_fields() -> None:
+    message = Message(
+        role="assistant",
+        content="answer",
+        provider_specific_fields={"internal": "value"},
+        reasoning_content="reasoning",
+        refusal="refusal",
+    )
+
+    assert _strip_unsupported_openai_message_fields([message]) == [
+        {"role": "assistant", "content": "answer"}
+    ]
+
+
+def test_strip_invalid_required_schema_fields_recursively() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "example",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"valid": {"type": "string"}},
+                    "required": ["valid", "missing"],
+                },
+            },
+        }
+    ]
+
+    sanitized = _strip_invalid_required_schema_fields(tools)
+
+    assert sanitized[0]["function"]["parameters"]["required"] == ["valid"]

--- a/agents/tests/test_react_toolbelt_config.py
+++ b/agents/tests/test_react_toolbelt_config.py
@@ -1,0 +1,18 @@
+from runner.agents.models import AgentRunInput
+from runner.agents.react_toolbelt_agent.main import ReActAgent
+
+
+def test_tool_call_timeout_comes_from_agent_config() -> None:
+    run_input = AgentRunInput(
+        trajectory_id="trajectory",
+        initial_messages=[],
+        mcp_gateway_url="http://localhost:8080/mcp",
+        mcp_gateway_auth_token=None,
+        orchestrator_model="openai/test-model",
+        orchestrator_extra_args=None,
+        agent_config_values={"tool_call_timeout": 123},
+    )
+
+    agent = ReActAgent(run_input)
+
+    assert agent.tool_call_timeout == 123

--- a/grading/runner/utils/llm.py
+++ b/grading/runner/utils/llm.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
 import litellm
 from litellm.exceptions import (
@@ -92,6 +92,23 @@ def _log_llm_route_once(workload: str | None = None) -> None:
 
 # Default concurrency limit for LLM calls
 LLM_CONCURRENCY_LIMIT = 10
+
+_UNSUPPORTED_OPENAI_MESSAGE_FIELDS = frozenset(
+    {"provider_specific_fields", "reasoning_content", "refusal"}
+)
+
+
+def _strip_unsupported_openai_message_fields(value: Any) -> Any:
+    """Return LiteLLM messages safe for strict OpenAI-compatible endpoints."""
+    if isinstance(value, list | tuple):
+        return [_strip_unsupported_openai_message_fields(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _strip_unsupported_openai_message_fields(item)
+            for key, item in value.items()
+            if key not in _UNSUPPORTED_OPENAI_MESSAGE_FIELDS and item is not None
+        }
+    return value
 
 # Context variable for grading run ID
 grading_run_id_ctx: ContextVar[str | None] = ContextVar("grading_run_id", default=None)
@@ -405,9 +422,13 @@ async def call_llm(
     Returns:
         ModelResponse from LiteLLM
     """
+    sanitized_messages = cast(
+        list[dict[str, Any]],
+        _strip_unsupported_openai_message_fields(messages),
+    )
     kwargs: dict[str, Any] = {
         "model": model,
-        "messages": _with_cached_system_prompt(messages, model),
+        "messages": _with_cached_system_prompt(sanitized_messages, model),
         "timeout": timeout,
         # Outer @with_retry owns retries — pin num_retries=0 so the LiteLLM
         # proxy doesn't retry on top, compounding caller × proxy attempts.

--- a/grading/runner/utils/token_utils.py
+++ b/grading/runner/utils/token_utils.py
@@ -25,7 +25,9 @@ DEFAULT_CONTEXT_LIMIT = 128000
 # Models where litellm uses tiktoken fallback and underestimates actual token count.
 # We apply a conservative multiplier to avoid exceeding context limits.
 CONSERVATIVE_TOKEN_MULTIPLIER_MODELS = {
-    "gemini": 1.9,  # Gemini tokenizer seems to produce atleast ~50% more tokens than tiktoken
+    # Large artifact payloads can substantially exceed LiteLLM's estimate when
+    # counted by Gemini server-side, so leave enough headroom for grading.
+    "gemini": 5.0,
 }
 
 

--- a/grading/tests/test_openai_compat.py
+++ b/grading/tests/test_openai_compat.py
@@ -1,0 +1,18 @@
+from runner.utils.llm import _strip_unsupported_openai_message_fields
+
+
+def test_strip_unsupported_openai_message_fields_recursively() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "content": "answer",
+            "provider_specific_fields": {"internal": "value"},
+            "reasoning_content": "reasoning",
+            "refusal": "refusal",
+            "optional": None,
+        }
+    ]
+
+    assert _strip_unsupported_openai_message_fields(messages) == [
+        {"role": "assistant", "content": "answer"}
+    ]

--- a/grading/tests/test_token_utils.py
+++ b/grading/tests/test_token_utils.py
@@ -1,0 +1,6 @@
+from runner.utils.token_utils import _get_token_multiplier
+
+
+def test_gemini_token_multiplier_leaves_conservative_headroom() -> None:
+    assert _get_token_multiplier("vertex_ai/gemini-3-flash") == 5.0
+    assert _get_token_multiplier("openai/gpt-5") == 1.0


### PR DESCRIPTION
## Summary
- sanitize unsupported LiteLLM message fields for strict OpenAI-compatible endpoints
- remove invalid JSON-schema `required` entries before tool submission
- increase Gemini grading token-estimation headroom
- make the ReAct tool-call timeout configurable

## Validation
- agents: 3 tests passed; Ruff passed
- grading: 2 tests passed; Ruff passed
- focused BasedPyright checks: 0 errors