### PR TITLE
feat(agents): add exact flat TITO capture

### DIFF
--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "trafilatura>=1.12.0",
     "pymupdf>=1.27.2",
     "tenacity>=9.0.0",
+    "renderers==0.1.8",
 ]
 
 [tool.setuptools]

--- a/agents/runner/main.py
+++ b/agents/runner/main.py
@@ -19,6 +19,7 @@ from runner.agents.models import (
 )
 from runner.agents.registry import get_agent_impl
 from runner.models import AgentConfig
+from runner.utils import tito_session
 from runner.utils.decorators import (
     agent_id_ctx,
     agent_version_ctx,
@@ -123,38 +124,51 @@ async def main(
             f"Running model {orchestrator_model} with agent {agent_config.agent_name}"
         )
 
+        _tito = tito_session.session_from_env(policy_model=orchestrator_model)
+        _tito_token = tito_session.set_active_session(_tito)
+
         try:
-            async with asyncio.timeout(settings.AGENT_TIMEOUT_SECONDS):
-                output = await agent_impl(run_input)
-        except TimeoutError:
-            logger.error(
-                f"Agent timed out after {settings.AGENT_TIMEOUT_SECONDS} seconds"
-            )
-            output = AgentTrajectoryOutput(
-                messages=[],
-                status=AgentStatus.ERROR,
-                time_elapsed=float(settings.AGENT_TIMEOUT_SECONDS),
-            )
-        except asyncio.CancelledError:
-            logger.error("Agent was cancelled externally")
-            output = AgentTrajectoryOutput(
-                messages=[],
-                status=AgentStatus.CANCELLED,
-                time_elapsed=0.0,
-            )
-        except Exception as e:
-            logger.error(f"Error running agent: {repr(e)}")
-            output = AgentTrajectoryOutput(
-                messages=[],
-                status=AgentStatus.ERROR,
-                time_elapsed=0.0,
-            )
+            try:
+                async with asyncio.timeout(settings.AGENT_TIMEOUT_SECONDS):
+                    output = await agent_impl(run_input)
+            except TimeoutError:
+                logger.error(
+                    f"Agent timed out after {settings.AGENT_TIMEOUT_SECONDS} seconds"
+                )
+                output = AgentTrajectoryOutput(
+                    messages=[],
+                    status=AgentStatus.ERROR,
+                    time_elapsed=float(settings.AGENT_TIMEOUT_SECONDS),
+                )
+            except asyncio.CancelledError:
+                logger.error("Agent was cancelled externally")
+                output = AgentTrajectoryOutput(
+                    messages=[],
+                    status=AgentStatus.CANCELLED,
+                    time_elapsed=0.0,
+                )
+            except Exception as e:
+                logger.error(f"Error running agent: {repr(e)}")
+                output = AgentTrajectoryOutput(
+                    messages=[],
+                    status=AgentStatus.ERROR,
+                    time_elapsed=0.0,
+                )
 
-        logger.info(f"Agent run finished with status {output.status}")
+            logger.info(f"Agent run finished with status {output.status}")
 
-        # save_results(trajectory_id, output, None)
+            if _tito is not None:
+                if output.status in (AgentStatus.ERROR, AgentStatus.CANCELLED):
+                    _tito.mark_incomplete(f"run status {output.status}")
+                output.output = tito_session.nest_in_output(
+                    output.output, _tito.output_dict()
+                )
 
-        return output
+            # save_results(trajectory_id, output, None)
+
+            return output
+        finally:
+            tito_session.reset_active_session(_tito_token)
 
 
 async def run_and_persist(

--- a/agents/runner/utils/llm.py
+++ b/agents/runner/utils/llm.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import Any
 
 import litellm
+import openai
 from litellm import acompletion, aresponses, get_model_info, token_counter
 from litellm.exceptions import (
     APIConnectionError,
@@ -25,7 +26,7 @@ from openai.types.chat.chat_completion_tool_param import ChatCompletionToolParam
 
 import runner.utils.litellm_patches  # noqa: F401
 from runner.agents.models import LitellmAnyMessage
-from runner.utils import budget_meter
+from runner.utils import budget_meter, tito_session
 from runner.utils.budget_hydration import request_meter_hydration
 from runner.utils.decorators import (
     account_id_ctx,
@@ -995,6 +996,10 @@ async def _budget_accrue(
         APIConnectionError,
         InternalServerError,
         BadGatewayError,
+        openai.RateLimitError,
+        openai.APITimeoutError,
+        openai.APIConnectionError,
+        openai.InternalServerError,
     ),
     skip_on=(ContextWindowExceededError,),
     skip_if=_should_skip_retry,
@@ -1022,6 +1027,16 @@ async def generate_response(
     Returns:
         The model response
     """
+    _tito = tito_session.get_active_session()
+    if _tito is not None and _tito.handles(model):
+        return await _tito.generate(
+            model,
+            messages,
+            tools,
+            responses_args_to_completions(extra_args),
+            llm_response_timeout,
+        )
+
     top_level_extra, extra_body = _split_extra_args(
         responses_args_to_completions(extra_args)
     )
@@ -1197,6 +1212,10 @@ async def generate_response(
         APIConnectionError,
         InternalServerError,
         BadGatewayError,
+        openai.RateLimitError,
+        openai.APITimeoutError,
+        openai.APIConnectionError,
+        openai.InternalServerError,
     ),
     skip_on=(ContextWindowExceededError,),
     skip_if=_should_skip_retry,
@@ -1226,6 +1245,16 @@ async def call_responses_api(
     Returns:
         The OpenAI responses API response object
     """
+    _tito = tito_session.get_active_session()
+    if _tito is not None and _tito.handles(model):
+        return await _tito.generate_responses(
+            model,
+            messages,
+            tools,
+            extra_args,
+            llm_response_timeout,
+        )
+
     top_level_extra, extra_body = _split_extra_args(extra_args)
     kwargs: dict[str, Any] = {
         "model": model,

--- a/agents/runner/utils/tito_capture.py
+++ b/agents/runner/utils/tito_capture.py
@@ -11,6 +11,7 @@ failing loud if the backend isn't capture-capable.
 from __future__ import annotations
 
 import math
+import os
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -20,7 +21,8 @@ from openai import AsyncOpenAI
 
 # Only the self-served policy backends we control may receive a capture call.
 # A bare/metadata/loopback IP never matches these suffixes, so it's rejected.
-_ALLOWED_HOST_SUFFIXES = (".modal.run", ".fireworks.ai")
+_ALLOWED_MODAL_SUFFIX = ".modal.run"
+_FIREWORKS_HOST = "api.fireworks.ai"
 _ALLOWED_LOCALHOSTS = ("localhost", "127.0.0.1")
 
 # Keys the harness's sampling args may safely control on both OpenAI-compatible
@@ -103,14 +105,22 @@ def validate_endpoint(api_base: str) -> None:
         raise ValueError(f"policy api_base must be http(s): {api_base!r}")
     host = (parsed.hostname or "").lower()
     is_localhost = host in _ALLOWED_LOCALHOSTS
-    if not (is_localhost or host.endswith(_ALLOWED_HOST_SUFFIXES)):
+    if not (
+        is_localhost or host == _FIREWORKS_HOST or host.endswith(_ALLOWED_MODAL_SUFFIX)
+    ):
         raise ValueError(f"policy api_base host not allowed: {host!r}")
     if parsed.scheme == "http" and not is_localhost:
         raise ValueError(f"remote policy api_base must use https: {api_base!r}")
+    allowed_origin = os.environ.get("MERCOR_POLICY_ALLOWED_ORIGIN", "").rstrip("/")
+    origin = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+    if allowed_origin and origin != allowed_origin:
+        raise ValueError(
+            f"policy api_base origin does not match configured origin: {origin!r}"
+        )
 
 
 def is_fireworks_endpoint(api_base: str) -> bool:
-    return (urlparse(api_base).hostname or "").lower().endswith(".fireworks.ai")
+    return (urlparse(api_base).hostname or "").lower() == _FIREWORKS_HOST
 
 
 def _policy_model_name(model: str) -> str:

--- a/agents/runner/utils/tito_capture.py
+++ b/agents/runner/utils/tito_capture.py
@@ -1,0 +1,361 @@
+"""Token-in / token-out transport for flat TITO capture.
+
+The buffer session (see ``tito_session``) owns the running token sequence and
+feeds *token ids* — never messages — to the self-served policy endpoint, so the
+tokens we record are byte-for-byte what the model conditioned on and sampled.
+This module is just the wire: call ``/completions`` with a token-id prompt and
+``return_token_ids`` + ``logprobs``, then normalize the provider response,
+failing loud if the backend isn't capture-capable.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from openai import AsyncOpenAI
+
+# Only the self-served policy backends we control may receive a capture call.
+# A bare/metadata/loopback IP never matches these suffixes, so it's rejected.
+_ALLOWED_HOST_SUFFIXES = (".modal.run", ".fireworks.ai")
+_ALLOWED_LOCALHOSTS = ("localhost", "127.0.0.1")
+
+# Keys the harness's sampling args may safely control on both OpenAI-compatible
+# vLLM and Fireworks text-completion endpoints.
+_ALLOWED_SAMPLING_KEYS = frozenset(
+    {
+        "max_tokens",
+        "max_output_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "frequency_penalty",
+        "presence_penalty",
+        "logit_bias",
+    }
+)
+_CAPTURE_OWNED_KEYS = frozenset(
+    {
+        "model",
+        "prompt",
+        "logprobs",
+        "top_logprobs",
+        "return_token_ids",
+        "stream",
+        "num_retries",
+        "max_retries",
+        "timeout",
+        "n",
+        "echo",
+        "best_of",
+    }
+)
+_ROUTING_KEYS = frozenset(
+    {
+        "api_base",
+        "base_url",
+        "api_key",
+        "api_version",
+        "custom_llm_provider",
+        "model_list",
+        "fallbacks",
+        "client",
+        "shared_session",
+        "extra_headers",
+        "extra_body",
+    }
+)
+
+_KNOWN_PROVIDER_PREFIXES = (
+    "responses/",
+    "fireworks_ai/",
+    "hosted_vllm/",
+    "vllm/",
+)
+
+
+@dataclass(frozen=True)
+class TokenCompletion:
+    prompt_token_ids: list[int]
+    completion_token_ids: list[int]
+    token_logprobs: list[float]
+    text: str
+    finish_reason: str | None
+    native_finish_reason: str | None
+    usage: dict[str, int]
+    request_id: str | None
+    model: str | None
+
+
+def validate_endpoint(api_base: str) -> None:
+    """Reject any endpoint that is not a self-served policy backend (SSRF guard).
+
+    Capture forwards the policy api_key and forces logprobs/return_token_ids, so
+    it must only ever reach configured policy hosts. Plain http is allowed for
+    localhost only; everything remote must be https.
+    """
+    parsed = urlparse(api_base)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"policy api_base must be http(s): {api_base!r}")
+    host = (parsed.hostname or "").lower()
+    is_localhost = host in _ALLOWED_LOCALHOSTS
+    if not (is_localhost or host.endswith(_ALLOWED_HOST_SUFFIXES)):
+        raise ValueError(f"policy api_base host not allowed: {host!r}")
+    if parsed.scheme == "http" and not is_localhost:
+        raise ValueError(f"remote policy api_base must use https: {api_base!r}")
+
+
+def is_fireworks_endpoint(api_base: str) -> bool:
+    return (urlparse(api_base).hostname or "").lower().endswith(".fireworks.ai")
+
+
+def _policy_model_name(model: str) -> str:
+    """Strip outer routing prefixes while preserving model namespaces."""
+    name = model
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _KNOWN_PROVIDER_PREFIXES:
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                changed = True
+                break
+    return name
+
+
+def _number(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"TITO sampling argument {name!r} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"TITO sampling argument {name!r} must be finite")
+    return result
+
+
+def _validated_sampling_args(sampling_args: dict[str, Any]) -> dict[str, Any]:
+    forbidden = sorted(set(sampling_args).intersection(_ROUTING_KEYS))
+    if forbidden:
+        raise ValueError(f"unsupported TITO sampling argument: {forbidden[0]}")
+    unknown = sorted(
+        set(sampling_args).difference(_ALLOWED_SAMPLING_KEYS, _CAPTURE_OWNED_KEYS)
+    )
+    if unknown:
+        raise ValueError(f"unsupported TITO sampling argument: {unknown[0]}")
+
+    values = {
+        key: value
+        for key, value in sampling_args.items()
+        if key in _ALLOWED_SAMPLING_KEYS and value is not None
+    }
+    aliases = [
+        key
+        for key in ("max_tokens", "max_output_tokens", "max_completion_tokens")
+        if key in values
+    ]
+    if len(aliases) > 1:
+        raise ValueError("TITO accepts only one output-token limit")
+    if aliases:
+        raw_max = values.pop(aliases[0])
+        if isinstance(raw_max, bool) or not isinstance(raw_max, int) or raw_max <= 0:
+            raise ValueError("TITO max_tokens must be a positive integer")
+        values["max_tokens"] = raw_max
+    if "temperature" in values and _number(values["temperature"], "temperature") < 0:
+        raise ValueError("TITO temperature must be nonnegative")
+    if "top_p" in values:
+        top_p = _number(values["top_p"], "top_p")
+        if not 0 <= top_p <= 1:
+            raise ValueError("TITO top_p must be between 0 and 1")
+    if "seed" in values and (
+        isinstance(values["seed"], bool) or not isinstance(values["seed"], int)
+    ):
+        raise ValueError("TITO seed must be an integer")
+    for name in ("frequency_penalty", "presence_penalty"):
+        if name in values:
+            penalty = _number(values[name], name)
+            if not -2 <= penalty <= 2:
+                raise ValueError(f"TITO {name} must be between -2 and 2")
+    if "logit_bias" in values:
+        bias = values["logit_bias"]
+        if not isinstance(bias, dict):
+            raise ValueError("TITO logit_bias must be a dictionary")
+        normalized_bias: dict[str, int] = {}
+        for token, value in bias.items():
+            if isinstance(token, bool):
+                raise ValueError("TITO logit_bias keys must be token IDs")
+            if isinstance(token, int):
+                token_id = token
+            elif isinstance(token, str) and token.isdecimal():
+                token_id = int(token)
+            else:
+                raise ValueError("TITO logit_bias keys must be token IDs")
+            if (
+                token_id < 0
+                or isinstance(value, bool)
+                or not isinstance(value, int)
+                or not -100 <= value <= 100
+            ):
+                raise ValueError("TITO logit_bias contains an invalid entry")
+            normalized_bias[str(token_id)] = value
+        values["logit_bias"] = normalized_bias
+    return values
+
+
+async def _request_completion(
+    *,
+    model: str,
+    prompt_token_ids: list[int],
+    sampling_args: dict[str, Any],
+    api_base: str,
+    api_key: str,
+    timeout: float | int,
+) -> Any:
+    async with httpx.AsyncClient(follow_redirects=False) as http_client:
+        client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=api_base,
+            http_client=http_client,
+            max_retries=0,
+            timeout=timeout,
+        )
+        response = await client.completions.with_raw_response.create(
+            model=model,
+            prompt=prompt_token_ids,
+            logprobs=1,
+            n=1,
+            echo=False,
+            extra_body={"return_token_ids": True},
+            **sampling_args,
+        )
+        return response.parse()
+
+
+async def generate_tokens(
+    *,
+    model: str,
+    prompt_token_ids: list[int],
+    sampling_args: dict[str, Any],
+    api_base: str,
+    api_key: str,
+    timeout: float | int,
+) -> TokenCompletion:
+    """Feed token ids to the policy ``/completions`` endpoint."""
+    validate_endpoint(api_base)
+    if not prompt_token_ids:
+        raise ValueError("TITO prompt token IDs must be nonempty")
+    fwd = _validated_sampling_args(sampling_args)
+    validated_prompt = _validated_ids(prompt_token_ids, "prompt token IDs")
+    resp = await _request_completion(
+        model=_policy_model_name(model),
+        prompt_token_ids=validated_prompt,
+        sampling_args=fwd,
+        api_base=api_base,
+        api_key=api_key,
+        timeout=timeout,
+    )
+    return extract_completion(resp, prompt_token_ids=validated_prompt)
+
+
+def _mapping_value(obj: Any, key: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _token_ids_from_choice(choice: Any) -> list[int] | None:
+    """Sampled token ids from a /completions choice across provider versions."""
+    ids = _mapping_value(choice, "token_ids")
+    psf = _mapping_value(choice, "provider_specific_fields") or {}
+    if ids is None and isinstance(psf, dict):
+        ids = psf.get("token_ids")
+    logprobs = _mapping_value(choice, "logprobs")
+    if ids is None and logprobs is not None:
+        ids = _mapping_value(logprobs, "token_ids")
+    return list(ids) if ids is not None else None
+
+
+def _validated_ids(values: list[Any], name: str) -> list[int]:
+    ids: list[int] = []
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise RuntimeError(f"TITO {name} contain an invalid token ID")
+        ids.append(value)
+    return ids
+
+
+def _usage_dict(prompt_count: int, completion_count: int) -> dict[str, int]:
+    return {
+        "prompt_tokens": prompt_count,
+        "completion_tokens": completion_count,
+        "total_tokens": prompt_count + completion_count,
+    }
+
+
+def extract_completion(resp: Any, *, prompt_token_ids: list[int]) -> TokenCompletion:
+    """Normalize one token-in completion response and enforce tape invariants."""
+    choices = _mapping_value(resp, "choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise RuntimeError("TITO capture requires exactly one completion choice")
+    choice = choices[0]
+    raw_ids = _token_ids_from_choice(choice)
+    if raw_ids is None:
+        raise RuntimeError(
+            "TITO capture requires a capture-capable backend that returns token "
+            "ids (vLLM / Fireworks `return_token_ids`); got none."
+        )
+    response_ids = _validated_ids(raw_ids, "completion token IDs")
+    returned_prompt = _mapping_value(resp, "prompt_token_ids")
+    if returned_prompt is not None:
+        validated_prompt = _validated_ids(
+            list(returned_prompt), "returned prompt token IDs"
+        )
+        if validated_prompt != prompt_token_ids:
+            raise RuntimeError("TITO backend changed the supplied prompt token IDs")
+
+    lp = _mapping_value(choice, "logprobs")
+    raw_logprobs = _mapping_value(lp, "token_logprobs") if lp is not None else None
+    logprobs = list(raw_logprobs) if raw_logprobs is not None else []
+    if len(logprobs) != len(response_ids):
+        raise RuntimeError(
+            f"TITO logprobs unusable: {len(logprobs)} logprobs vs "
+            f"{len(response_ids)} response tokens."
+        )
+    normalized_logprobs: list[float] = []
+    for value in logprobs:
+        if value is None:
+            raise RuntimeError("TITO logprobs contain null values.")
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise RuntimeError("TITO logprobs contain non-numeric values.")
+        normalized = float(value)
+        if not math.isfinite(normalized):
+            raise RuntimeError("TITO logprobs contain non-finite values.")
+        normalized_logprobs.append(normalized)
+
+    finish = _mapping_value(choice, "finish_reason")
+    finish_reason = str(finish) if finish is not None else None
+    psf = _mapping_value(choice, "provider_specific_fields")
+    native_finish = psf.get("native_finish_reason") if isinstance(psf, dict) else None
+    text = _mapping_value(choice, "text")
+    usage = _usage_dict(len(prompt_token_ids), len(response_ids))
+    return TokenCompletion(
+        prompt_token_ids=list(prompt_token_ids),
+        completion_token_ids=response_ids,
+        token_logprobs=normalized_logprobs,
+        text=text if isinstance(text, str) else "",
+        finish_reason=finish_reason,
+        native_finish_reason=(
+            str(native_finish) if native_finish is not None else finish_reason
+        ),
+        usage=usage,
+        request_id=_mapping_value(resp, "id"),
+        model=_mapping_value(resp, "model"),
+    )
+
+
+def extract_tokens(resp: Any) -> tuple[list[int], list[float]]:
+    """Backward-compatible extraction helper for focused unit tests."""
+    result = extract_completion(resp, prompt_token_ids=[])
+    return result.completion_token_ids, result.token_logprobs

--- a/agents/runner/utils/tito_renderer.py
+++ b/agents/runner/utils/tito_renderer.py
@@ -1,0 +1,233 @@
+"""Thin wrapper over Prime Intellect's ``renderers`` library for flat TITO.
+
+Isolates the heavy, lazily-imported ``renderers`` + ``transformers`` dependency
+and the policy-model -> HF-tokenizer resolution behind the small surface the
+capture session needs:
+
+  * ``render_ids``  — first turn: messages -> prompt token ids
+  * ``bridge``      — later turns: extend (prev_prompt, prev_completion) with the
+                      new tool/user messages, byte-for-byte, or ``None`` if the
+                      extension can't be proven safe (history rewrite, etc.)
+  * ``parse``       — sampled ids -> structured content/reasoning/tool calls so
+                      the harness loop keeps working unchanged
+
+Only exact text-only models registered by the pinned ``renderers`` release are
+accepted. Default and multimodal renderers cannot satisfy this transport's
+byte-coherence contract.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+# Provider/transport prefixes stripped to recover a bare model name.
+_PROVIDER_PREFIXES = (
+    "fireworks_ai/",
+    "hosted_vllm/",
+    "vllm/",
+    "openai/",
+)
+_RESPONSES_SEGMENT = "responses"
+
+
+@dataclass(frozen=True)
+class TitoParsedToolCall:
+    id: str | None
+    name: str
+    arguments: dict[str, Any] | str | None
+
+
+@dataclass(frozen=True)
+class TitoParsedResponse:
+    content: str | None
+    reasoning_content: str | None
+    tool_calls: list[TitoParsedToolCall]
+    parse_errors: list[str]
+
+
+@lru_cache(maxsize=1)
+def registered_text_model_ids() -> frozenset[str]:
+    from renderers.base import MODEL_RENDERER_MAP, MULTIMODAL_MODELS  # noqa: PLC0415
+
+    return frozenset(MODEL_RENDERER_MAP).difference(MULTIMODAL_MODELS)
+
+
+def _without_responses_segment(model: str) -> str:
+    return "/".join(part for part in model.split("/") if part != _RESPONSES_SEGMENT)
+
+
+def _model_candidates(model: str) -> list[str]:
+    name = _without_responses_segment(model)
+    candidates = [name]
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _PROVIDER_PREFIXES:
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                candidates.append(name)
+                changed = True
+                break
+    return candidates
+
+
+def resolve_hf_id(policy_model: str) -> str:
+    """HF tokenizer repo id for the policy model.
+
+    An explicit ``MERCOR_POLICY_HF_ID`` override wins, because provider ids
+    (Fireworks account paths, vLLM served names) don't map 1:1 to HF repos.
+    Otherwise resolve the first exact registered text-model candidate.
+    """
+    override = os.environ.get("MERCOR_POLICY_HF_ID", "").strip()
+    if override:
+        return override
+    supported = registered_text_model_ids()
+    for candidate in _model_candidates(policy_model):
+        if candidate in supported:
+            return candidate
+    return _without_responses_segment(policy_model)
+
+
+def validate_hf_id(hf_id: str) -> None:
+    if hf_id not in registered_text_model_ids():
+        raise RuntimeError(
+            f"TITO requires an exact text-only model registered by renderers: {hf_id!r}"
+        )
+
+
+def _is_default_renderer(renderer: Any) -> bool:
+    """True if ``renderers`` fell back to its generic, model-agnostic renderer."""
+    return type(renderer).__name__ == "DefaultRenderer"
+
+
+def _as_ids(rendered: Any) -> list[int]:
+    """Coerce a renderers return value to a token-id list."""
+    ids = getattr(rendered, "token_ids", rendered)
+    return list(ids)
+
+
+def _text_content(content: Any) -> Any:
+    if not isinstance(content, list):
+        return content
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            parts.append(part)
+            continue
+        if not isinstance(part, dict) or part.get("type") not in {
+            "text",
+            "input_text",
+            "output_text",
+        }:
+            raise ValueError("TITO text-only capture does not support non-text content")
+        text = part.get("text")
+        if not isinstance(text, str):
+            raise ValueError("TITO text-only content parts require string text")
+        parts.append(text)
+    return "".join(parts)
+
+
+def normalize_messages(messages: list[Any]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise ValueError("TITO renderer messages must serialize to dictionaries")
+        item = dict(message)
+        if "content" in item:
+            item["content"] = _text_content(item["content"])
+        normalized.append(item)
+    return normalized
+
+
+def _build_renderer(hf_id: str, chat_template_kwargs: dict[str, Any]) -> Any:
+    """Lazily import the heavy deps and build an exact registered renderer."""
+    from renderers import (  # noqa: PLC0415
+        AutoRendererConfig,
+        create_renderer,
+        is_multimodal,
+    )
+    from renderers.base import load_tokenizer  # noqa: PLC0415
+
+    validate_hf_id(hf_id)
+    tokenizer = load_tokenizer(hf_id)
+    renderer = create_renderer(
+        tokenizer,
+        AutoRendererConfig(thinking_retention="all"),
+        chat_template_kwargs=chat_template_kwargs or None,
+    )
+    if _is_default_renderer(renderer) or is_multimodal(renderer):
+        raise RuntimeError(f"TITO model is not text-only: {hf_id!r}")
+    return renderer
+
+
+class TitoRenderer:
+    """Renderers wrapper for one policy model and template configuration."""
+
+    def __init__(
+        self, hf_id: str, chat_template_kwargs: dict[str, Any] | None = None
+    ) -> None:
+        self.hf_id = hf_id
+        self.chat_template_kwargs = dict(chat_template_kwargs or {})
+        self._renderer = _build_renderer(hf_id, self.chat_template_kwargs)
+
+    def render_ids(self, messages: list[Any], tools: list[Any] | None) -> list[int]:
+        rendered = self._renderer.render(
+            normalize_messages(messages),
+            tools=tools,
+            add_generation_prompt=True,
+        )
+        if getattr(rendered, "multi_modal_data", None) is not None:
+            raise ValueError("TITO text-only capture received multimodal renderer data")
+        return _as_ids(rendered)
+
+    def bridge(
+        self,
+        prev_prompt_ids: list[int],
+        prev_completion_ids: list[int],
+        new_messages: list[Any],
+        tools: list[Any] | None,
+    ) -> list[int] | None:
+        """Extended next-turn prompt ids, or ``None`` if unsafe to extend."""
+        out = self._renderer.bridge_to_next_turn(
+            prev_prompt_ids,
+            prev_completion_ids,
+            normalize_messages(new_messages),
+            tools=tools,
+        )
+        if out is None:
+            return None
+        if getattr(out, "multi_modal_data", None) is not None:
+            raise ValueError("TITO text-only bridge received multimodal renderer data")
+        return _as_ids(out)
+
+    def parse(
+        self, completion_ids: list[int], tools: list[Any] | None
+    ) -> TitoParsedResponse:
+        """Parse sampled ids while retaining only valid executable tool calls."""
+        parsed = self._renderer.parse_response(completion_ids, tools=tools)
+        tool_calls: list[TitoParsedToolCall] = []
+        parse_errors: list[str] = []
+        for call in getattr(parsed, "tool_calls", None) or []:
+            status = getattr(getattr(call, "status", None), "value", None)
+            name = getattr(call, "name", None)
+            if status != "ok" or not isinstance(name, str) or not name:
+                parse_errors.append(str(status or "missing_name"))
+                continue
+            tool_calls.append(
+                TitoParsedToolCall(
+                    id=getattr(call, "id", None),
+                    name=name,
+                    arguments=getattr(call, "arguments", None),
+                )
+            )
+        content = getattr(parsed, "content", None)
+        reasoning = getattr(parsed, "reasoning_content", None)
+        return TitoParsedResponse(
+            content=content if isinstance(content, str) else None,
+            reasoning_content=reasoning if isinstance(reasoning, str) else None,
+            tool_calls=tool_calls,
+            parse_errors=parse_errors,
+        )

--- a/agents/runner/utils/tito_session.py
+++ b/agents/runner/utils/tito_session.py
@@ -200,8 +200,10 @@ def _normalize_responses_messages(messages: list[Any]) -> list[dict[str, Any]]:
             message = {"role": normalized_role, "content": item.get("content")}
             for key in ("reasoning_content", "tool_calls", "tool_call_id", "name"):
                 if item.get(key) is not None:
-                    message[key] = item[key]
+                    message[key] = list(item[key]) if key == "tool_calls" else item[key]
             out.append(message)
+            continue
+        if item_type == "reasoning":
             continue
         if item_type == "function_call":
             tool_call = {

--- a/agents/runner/utils/tito_session.py
+++ b/agents/runner/utils/tito_session.py
@@ -1,0 +1,711 @@
+"""Flat TITO capture: env gate + per-rollout running token buffer.
+
+Enabled only when ``MERCOR_TITO_CAPTURE=true`` — default-off so normal
+trajectory runs are untouched. When active, the central Chat and Responses LLM
+paths hand policy-model calls to :class:`TitoCaptureSession`, which feeds token
+IDs to the policy endpoint, reconstructs the harness response, and grows one
+flat sequence only while each turn is a provable append-only extension.
+
+If a turn cannot be proven safe, the tape freezes with ``tito_complete=false``.
+The model request is still served from a full render, but no further tokens are
+appended to the flat training sequence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import json
+import os
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from litellm import Choices
+from litellm.files.main import ModelResponse
+from litellm.types.utils import Message, Usage
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from runner.utils import tito_capture, tito_renderer
+
+_active: contextvars.ContextVar[TitoCaptureSession | None] = contextvars.ContextVar(
+    "tito_session", default=None
+)
+
+_RESPONSES_SEGMENT = "responses"
+
+
+class _TapeMode(StrEnum):
+    """Whether the flat token tape still accepts append-only extensions."""
+
+    RECORDING = "recording"
+    FROZEN = "frozen"
+
+
+@dataclass(frozen=True)
+class _TurnPlan:
+    """Side-effect-free plan for one policy-model call."""
+
+    renderer: Any
+    prompt_ids: list[int]
+    tape_delta: list[int]
+    append_to_tape: bool
+    freeze_reason: str | None
+    messages: list[Any]
+    tools: list[Any] | None
+    tools_key: str
+    template_key: str
+
+
+@dataclass(frozen=True)
+class _ParsedAssistant:
+    content: str | None
+    reasoning: str | None
+    tool_calls: list[dict[str, Any]]
+    parse_errors: list[str]
+
+
+class TitoResponsesUsage(BaseModel):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    output_tokens_details: dict[str, int] = Field(
+        default_factory=lambda: {"reasoning_tokens": 0}
+    )
+
+
+class TitoResponsesResponse(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    object: str = "response"
+    model: str
+    status: str
+    output: list[dict[str, Any]]
+    usage: TitoResponsesUsage
+    incomplete_details: dict[str, str] | None = None
+
+
+def get_active_session() -> TitoCaptureSession | None:
+    return _active.get()
+
+
+def set_active_session(
+    session: TitoCaptureSession | None,
+) -> contextvars.Token[TitoCaptureSession | None]:
+    return _active.set(session)
+
+
+def reset_active_session(
+    token: contextvars.Token[TitoCaptureSession | None],
+) -> None:
+    _active.reset(token)
+
+
+def nest_in_output(
+    harness_output: dict[str, Any] | None, tito_payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge capture under ``output["tito"]`` without clobbering harness keys."""
+    return {**(harness_output or {}), "tito": tito_payload}
+
+
+def _canonical_model(model: str) -> str:
+    return "/".join(part for part in model.split("/") if part != _RESPONSES_SEGMENT)
+
+
+def session_from_env(policy_model: str | None) -> TitoCaptureSession | None:
+    """Build a capture session from the environment, or ``None`` if disabled."""
+    if os.environ.get("MERCOR_TITO_CAPTURE", "").strip().lower() != "true":
+        return None
+    api_base = os.environ.get("MERCOR_POLICY_API_BASE", "").strip()
+    if not api_base:
+        raise RuntimeError(
+            "MERCOR_TITO_CAPTURE is set but MERCOR_POLICY_API_BASE is missing."
+        )
+    if policy_model is None:
+        raise RuntimeError("TITO capture needs a policy model but none was provided.")
+    hf_id = tito_renderer.resolve_hf_id(policy_model)
+    tito_renderer.validate_hf_id(hf_id)
+    served_model = os.environ.get(
+        "MERCOR_POLICY_SERVED_MODEL", ""
+    ).strip() or _canonical_model(policy_model)
+    explicit_key = os.environ.get("MERCOR_POLICY_API_KEY")
+    api_key = explicit_key or (
+        os.environ.get("FIREWORKS_API_KEY")
+        if tito_capture.is_fireworks_endpoint(api_base)
+        else None
+    )
+    tito_capture.validate_endpoint(api_base)
+    default_max_tokens = int(os.environ.get("MERCOR_TITO_MAX_TOKENS", "8192"))
+    if default_max_tokens <= 0:
+        raise RuntimeError("MERCOR_TITO_MAX_TOKENS must be positive")
+    return TitoCaptureSession(
+        policy_model=policy_model,
+        served_model=served_model,
+        hf_id=hf_id,
+        api_base=api_base,
+        api_key=api_key or "dummy",
+        default_max_tokens=default_max_tokens,
+    )
+
+
+def _as_payload(obj: Any) -> Any:
+    """Serialize litellm/pydantic message + tool objects to JSON-safe values."""
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(exclude_none=True)
+    return obj
+
+
+def _json_key(value: Any, *, sort_keys: bool) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=sort_keys,
+        default=str,
+    )
+
+
+def _tool_calls_to_dicts(
+    tool_calls: list[tito_renderer.TitoParsedToolCall],
+) -> list[dict[str, Any]] | None:
+    if not tool_calls:
+        return None
+    out: list[dict[str, Any]] = []
+    for i, call in enumerate(tool_calls):
+        arguments = call.arguments
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments if arguments is not None else {})
+        out.append(
+            {
+                "id": call.id or f"tito_call_{i}",
+                "type": "function",
+                "function": {"name": call.name, "arguments": arguments},
+            }
+        )
+    return out
+
+
+def _normalize_responses_messages(messages: list[Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for raw in messages:
+        item = _as_payload(raw)
+        if not isinstance(item, dict):
+            raise ValueError("TITO Responses inputs must be dictionaries")
+        role = item.get("role")
+        item_type = item.get("type")
+        if isinstance(role, str):
+            normalized_role = "system" if role == "developer" else role
+            message = {"role": normalized_role, "content": item.get("content")}
+            for key in ("reasoning_content", "tool_calls", "tool_call_id", "name"):
+                if item.get(key) is not None:
+                    message[key] = item[key]
+            out.append(message)
+            continue
+        if item_type == "function_call":
+            tool_call = {
+                "id": item.get("call_id") or item.get("id"),
+                "type": "function",
+                "function": {
+                    "name": item.get("name"),
+                    "arguments": item.get("arguments") or "{}",
+                },
+            }
+            if out and out[-1].get("role") == "assistant":
+                out[-1].setdefault("tool_calls", []).append(tool_call)
+            else:
+                out.append({"role": "assistant", "tool_calls": [tool_call]})
+            continue
+        if item_type == "function_call_output":
+            out.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id"),
+                    "content": item.get("output") or "",
+                }
+            )
+            continue
+        raise ValueError(f"TITO does not support Responses input item {item_type!r}")
+    return tito_renderer.normalize_messages(out)
+
+
+def _normalize_responses_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") != "function":
+            raise ValueError(
+                f"TITO does not support provider-hosted Responses tool {tool.get('type')!r}"
+            )
+        if isinstance(tool.get("function"), dict):
+            normalized.append(dict(tool))
+            continue
+        function: dict[str, Any] = {"name": tool.get("name")}
+        if tool.get("description") is not None:
+            function["description"] = tool["description"]
+        if tool.get("parameters") is not None:
+            function["parameters"] = tool["parameters"]
+        if tool.get("strict") is not None:
+            function["strict"] = tool["strict"]
+        normalized.append({"type": "function", "function": function})
+    return normalized
+
+
+class TitoCaptureSession:
+    def __init__(
+        self,
+        *,
+        policy_model: str,
+        hf_id: str,
+        api_base: str,
+        api_key: str,
+        default_max_tokens: int,
+        served_model: str | None = None,
+    ) -> None:
+        self._policy_model = policy_model
+        self._served_model = served_model or policy_model
+        self._hf_id = hf_id
+        self._api_base = api_base
+        self._api_key = api_key
+        self._default_max_tokens = default_max_tokens
+        self._renderer: Any | None = None
+        self._renderers: dict[str, tito_renderer.TitoRenderer] = {}
+        self._token_ids: list[int] = []
+        self._loss_mask: list[int] = []
+        self._logprobs: list[float] = []
+        self._prev_prompt_ids: list[int] | None = None
+        self._prev_completion_ids: list[int] = []
+        self._prev_messages: list[Any] | None = None
+        self._expected_echo: Any = None
+        self._prev_tools_key: str | None = None
+        self._prev_template_key: str | None = None
+        self._tape_mode = _TapeMode.RECORDING
+        self._capture_complete = True
+        self._error: str | None = None
+        self._calls_seen = 0
+        self._lock = asyncio.Lock()
+
+    def handles(self, model: str) -> bool:
+        """Capture only the policy model; auxiliary models take the normal path."""
+        return _canonical_model(model) == _canonical_model(self._policy_model)
+
+    def _split_request_args(
+        self, extra_args: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        args = dict(extra_args)
+        template = args.pop("chat_template_kwargs", None) or {}
+        if not isinstance(template, dict):
+            raise ValueError("TITO chat_template_kwargs must be a dictionary")
+        template = dict(template)
+        extra_body = args.pop("extra_body", None)
+        if extra_body is not None:
+            if not isinstance(extra_body, dict):
+                raise ValueError("TITO extra_body must be a dictionary")
+            nested = dict(extra_body)
+            nested_template = nested.pop("chat_template_kwargs", None)
+            if nested_template is not None:
+                if template or not isinstance(nested_template, dict):
+                    raise ValueError("TITO received conflicting chat_template_kwargs")
+                template = dict(nested_template)
+            reasoning = nested.pop("reasoning", None)
+            if isinstance(reasoning, dict) and reasoning.get("effort") is not None:
+                args.setdefault("reasoning_effort", reasoning["effort"])
+            if nested:
+                raise ValueError(
+                    f"unsupported TITO sampling argument: {sorted(nested)[0]}"
+                )
+        top_level_reasoning = args.pop("reasoning", None)
+        if isinstance(top_level_reasoning, dict):
+            args.setdefault("reasoning_effort", top_level_reasoning.get("effort"))
+        elif top_level_reasoning is not None:
+            raise ValueError("TITO reasoning must be a dictionary")
+        reasoning_effort = args.pop("reasoning_effort", None)
+        if reasoning_effort is not None:
+            try:
+                from renderers.base import MODEL_RENDERER_MAP  # noqa: PLC0415
+
+                renderer_name = MODEL_RENDERER_MAP[self._hf_id]
+            except (ImportError, KeyError):
+                renderer_name = ""
+            if renderer_name in {"gpt-oss", "hy3"}:
+                template.setdefault("reasoning_effort", reasoning_effort)
+        tool_choice = args.pop("tool_choice", None)
+        if tool_choice not in (None, "auto"):
+            raise ValueError("TITO supports only automatic tool choice")
+        parallel = args.pop("parallel_tool_calls", None)
+        if parallel not in (None, True):
+            raise ValueError("TITO cannot enforce parallel_tool_calls=false")
+        if args.pop("response_format", None) is not None:
+            raise ValueError("TITO does not support response_format")
+        for key in ("max_tokens", "max_output_tokens", "max_completion_tokens"):
+            if args.get(key) is None:
+                args.pop(key, None)
+        output_limits = [
+            key
+            for key in ("max_tokens", "max_output_tokens", "max_completion_tokens")
+            if key in args
+        ]
+        if len(output_limits) > 1:
+            raise ValueError("TITO accepts only one output-token limit")
+        if output_limits and output_limits[0] != "max_tokens":
+            args["max_tokens"] = args.pop(output_limits[0])
+        elif not output_limits:
+            args["max_tokens"] = self._default_max_tokens
+        return template, args
+
+    def _get_renderer(self, template: dict[str, Any]) -> Any:
+        if self._renderer is not None:
+            return self._renderer
+        key = _json_key(template, sort_keys=True)
+        renderer = self._renderers.get(key)
+        if renderer is None:
+            renderer = tito_renderer.TitoRenderer(self._hf_id, template)
+            self._renderers[key] = renderer
+        return renderer
+
+    def _plan_turn(
+        self,
+        renderer: Any,
+        messages: list[Any],
+        tools: list[Any] | None,
+        template_key: str,
+    ) -> _TurnPlan:
+        tools_key = _json_key(tools or [], sort_keys=False)
+        if self._prev_prompt_ids is None or self._tape_mode == _TapeMode.FROZEN:
+            prompt_ids = renderer.render_ids(messages, tools)
+            return _TurnPlan(
+                renderer=renderer,
+                prompt_ids=prompt_ids,
+                tape_delta=prompt_ids if not self._token_ids else [],
+                append_to_tape=not self._token_ids
+                and self._tape_mode == _TapeMode.RECORDING,
+                freeze_reason=None,
+                messages=messages,
+                tools=tools,
+                tools_key=tools_key,
+                template_key=template_key,
+            )
+
+        reason: str | None = None
+        observations: list[Any] = []
+        previous = self._prev_messages or []
+        if tools_key != self._prev_tools_key:
+            reason = "tool definitions changed"
+        elif template_key != self._prev_template_key:
+            reason = "chat template configuration changed"
+        elif messages[: len(previous)] != previous:
+            reason = "message history was rewritten"
+        else:
+            tail = messages[len(previous) :]
+            if not tail or tail[0] != self._expected_echo:
+                reason = "previous assistant response was not echoed exactly"
+            else:
+                observations = tail[1:]
+                if not observations:
+                    reason = "message list did not add an observation"
+
+        if reason is None:
+            bridged = renderer.bridge(
+                self._prev_prompt_ids,
+                self._prev_completion_ids,
+                observations,
+                tools,
+            )
+            prefix = self._prev_prompt_ids + self._prev_completion_ids
+            if bridged is None:
+                reason = "renderer could not safely extend the turn"
+            elif bridged[: len(prefix)] != prefix:
+                reason = "renderer bridge did not preserve the sampled prefix"
+            else:
+                return _TurnPlan(
+                    renderer=renderer,
+                    prompt_ids=bridged,
+                    tape_delta=bridged[len(prefix) :],
+                    append_to_tape=True,
+                    freeze_reason=None,
+                    messages=messages,
+                    tools=tools,
+                    tools_key=tools_key,
+                    template_key=template_key,
+                )
+
+        return _TurnPlan(
+            renderer=renderer,
+            prompt_ids=renderer.render_ids(messages, tools),
+            tape_delta=[],
+            append_to_tape=False,
+            freeze_reason=reason,
+            messages=messages,
+            tools=tools,
+            tools_key=tools_key,
+            template_key=template_key,
+        )
+
+    async def _complete(
+        self,
+        messages: list[Any],
+        tools: list[Any] | None,
+        extra_args: dict[str, Any],
+        timeout: float | int,
+        *,
+        surface: str,
+    ) -> ModelResponse | TitoResponsesResponse:
+        async with self._lock:
+            template, sampling = self._split_request_args(extra_args)
+            renderer = self._get_renderer(template)
+            plan = self._plan_turn(
+                renderer,
+                messages,
+                tools,
+                _json_key(template, sort_keys=True),
+            )
+            completion = await tito_capture.generate_tokens(
+                model=self._served_model,
+                prompt_token_ids=plan.prompt_ids,
+                sampling_args=sampling,
+                api_base=self._api_base,
+                api_key=self._api_key,
+                timeout=timeout,
+            )
+            parsed = self._parse(renderer, completion.completion_token_ids, tools)
+            assistant_payload = self._assistant_payload(
+                parsed, include_reasoning=surface == "chat"
+            )
+            if surface == "responses":
+                response: ModelResponse | TitoResponsesResponse = (
+                    self._build_responses_response(parsed, completion)
+                )
+            else:
+                response = self._build_chat_response(parsed, completion)
+            self._commit(plan, completion, assistant_payload)
+            if parsed.parse_errors:
+                self._freeze_tape("renderer could not parse a tool call unambiguously")
+            return response
+
+    async def generate(
+        self,
+        model: str,
+        messages: list[Any],
+        tools: list[Any] | None,
+        sampling_args: dict[str, Any],
+        timeout: float | int,
+    ) -> ModelResponse:
+        del model
+        payload_messages = [_as_payload(message) for message in messages]
+        payload_tools = (
+            [_as_payload(tool) for tool in tools] if tools is not None else None
+        )
+        response = await self._complete(
+            payload_messages,
+            payload_tools,
+            sampling_args,
+            timeout,
+            surface="chat",
+        )
+        if not isinstance(response, ModelResponse):
+            raise RuntimeError("TITO returned the wrong Chat response type")
+        return response
+
+    async def generate_responses(
+        self,
+        model: str,
+        messages: list[Any],
+        tools: list[dict[str, Any]],
+        extra_args: dict[str, Any],
+        timeout: float | int,
+    ) -> TitoResponsesResponse:
+        del model
+        response = await self._complete(
+            _normalize_responses_messages(messages),
+            _normalize_responses_tools(tools),
+            extra_args,
+            timeout,
+            surface="responses",
+        )
+        if not isinstance(response, TitoResponsesResponse):
+            raise RuntimeError("TITO returned the wrong Responses response type")
+        return response
+
+    @staticmethod
+    def _parse(
+        renderer: Any, response_ids: list[int], tools: list[Any] | None
+    ) -> _ParsedAssistant:
+        parsed = renderer.parse(response_ids, tools)
+        calls = _tool_calls_to_dicts(parsed.tool_calls) or []
+        return _ParsedAssistant(
+            parsed.content,
+            parsed.reasoning_content,
+            calls,
+            parsed.parse_errors,
+        )
+
+    @staticmethod
+    def _assistant_payload(
+        parsed: _ParsedAssistant, *, include_reasoning: bool
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"role": "assistant"}
+        if parsed.content is not None:
+            payload["content"] = parsed.content
+        if include_reasoning and parsed.reasoning:
+            payload["reasoning_content"] = parsed.reasoning
+        if parsed.tool_calls:
+            payload["tool_calls"] = parsed.tool_calls
+        return payload
+
+    def _build_chat_response(
+        self,
+        parsed: _ParsedAssistant,
+        completion: tito_capture.TokenCompletion,
+    ) -> ModelResponse:
+        message = Message(
+            role="assistant",
+            content=parsed.content,
+            tool_calls=parsed.tool_calls or None,
+        )
+        if parsed.reasoning:
+            message.reasoning_content = parsed.reasoning  # type: ignore[attr-defined]
+        finish_reason = (
+            "tool_calls" if parsed.tool_calls else completion.finish_reason or "stop"
+        )
+        choice = Choices(finish_reason=finish_reason, index=0, message=message)
+        usage = Usage(
+            prompt_tokens=completion.usage["prompt_tokens"],
+            completion_tokens=completion.usage["completion_tokens"],
+            total_tokens=completion.usage["total_tokens"],
+        )
+        return ModelResponse(
+            id=completion.request_id,
+            model=completion.model or self._served_model,
+            choices=[choice],
+            usage=usage,
+        )
+
+    def _build_responses_response(
+        self,
+        parsed: _ParsedAssistant,
+        completion: tito_capture.TokenCompletion,
+    ) -> TitoResponsesResponse:
+        output: list[dict[str, Any]] = []
+        if parsed.reasoning:
+            output.append(
+                {
+                    "type": "reasoning",
+                    "status": "completed",
+                    "content": [{"type": "reasoning_text", "text": parsed.reasoning}],
+                    "summary": [{"type": "summary_text", "text": parsed.reasoning}],
+                }
+            )
+        if parsed.content:
+            output.append(
+                {
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": parsed.content,
+                            "annotations": [],
+                        }
+                    ],
+                }
+            )
+        for call in parsed.tool_calls:
+            function = call["function"]
+            output.append(
+                {
+                    "type": "function_call",
+                    "status": "completed",
+                    "id": call["id"],
+                    "call_id": call["id"],
+                    "name": function["name"],
+                    "arguments": function["arguments"],
+                }
+            )
+        finish = completion.finish_reason
+        status = "incomplete" if finish in {"length", "content_filter"} else "completed"
+        incomplete = None
+        if finish == "length":
+            incomplete = {"reason": "max_output_tokens"}
+        elif finish == "content_filter":
+            incomplete = {"reason": "content_filter"}
+        usage = TitoResponsesUsage(
+            input_tokens=completion.usage["prompt_tokens"],
+            output_tokens=completion.usage["completion_tokens"],
+            total_tokens=completion.usage["total_tokens"],
+        )
+        return TitoResponsesResponse(
+            id=completion.request_id or "resp_tito",
+            model=completion.model or self._served_model,
+            status=status,
+            output=output,
+            usage=usage,
+            incomplete_details=incomplete,
+        )
+
+    def _commit(
+        self,
+        plan: _TurnPlan,
+        completion: tito_capture.TokenCompletion,
+        assistant_payload: dict[str, Any],
+    ) -> None:
+        if plan.freeze_reason is not None:
+            self._freeze_tape(plan.freeze_reason)
+        elif plan.append_to_tape:
+            self._append(plan.tape_delta, mask=0)
+            self._append(
+                completion.completion_token_ids,
+                mask=1,
+                logprobs=completion.token_logprobs,
+            )
+            self._prev_prompt_ids = plan.prompt_ids
+            self._prev_completion_ids = completion.completion_token_ids
+            self._prev_messages = plan.messages
+            self._expected_echo = assistant_payload
+            self._prev_tools_key = plan.tools_key
+            self._prev_template_key = plan.template_key
+        self._calls_seen += 1
+        self._check_invariants()
+
+    def _append(
+        self, ids: list[int], *, mask: int, logprobs: list[float] | None = None
+    ) -> None:
+        if logprobs is not None and len(ids) != len(logprobs):
+            raise RuntimeError("TITO append received misaligned token logprobs")
+        self._token_ids.extend(ids)
+        self._loss_mask.extend([mask] * len(ids))
+        self._logprobs.extend([0.0] * len(ids) if logprobs is None else list(logprobs))
+
+    def _check_invariants(self) -> None:
+        if not (len(self._token_ids) == len(self._loss_mask) == len(self._logprobs)):
+            raise RuntimeError("TITO tape arrays are misaligned")
+
+    def _freeze_tape(self, reason: str) -> None:
+        if self._tape_mode == _TapeMode.RECORDING:
+            logger.warning(f"TITO flat capture abandoned: {reason}")
+        self._tape_mode = _TapeMode.FROZEN
+        self.mark_incomplete(reason)
+
+    def mark_incomplete(self, reason: str) -> None:
+        self._capture_complete = False
+        if self._error is None:
+            self._error = reason or "capture incomplete"
+
+    def output_dict(self) -> dict[str, Any]:
+        """Serialize the flat sequence for ``AgentTrajectoryOutput.output["tito"]``."""
+        self._check_invariants()
+        complete = self._capture_complete and self._calls_seen > 0
+        error = self._error
+        if self._calls_seen == 0 and error is None:
+            error = "no matching central policy call was captured"
+        out: dict[str, Any] = {
+            "tito_version": 1,
+            "tito_complete": complete,
+            "hf_model_id": self._hf_id,
+            "token_ids": self._token_ids,
+            "loss_mask": self._loss_mask,
+            "logprobs": self._logprobs,
+        }
+        if error is not None:
+            out["tito_error"] = error
+        return out

--- a/agents/tests/test_tito_capture.py
+++ b/agents/tests/test_tito_capture.py
@@ -73,7 +73,7 @@ def test_extract_allows_empty_completion() -> None:
     "api_base",
     [
         "https://my-policy.modal.run/v1",
-        "https://acct-1.fireworks.ai/inference/v1",
+        "https://api.fireworks.ai/inference/v1",
         "http://localhost:8000/v1",
         "http://127.0.0.1:8000/v1",
     ],
@@ -88,6 +88,7 @@ def test_validate_endpoint_allows_controlled_hosts(api_base: str) -> None:
         "https://evil.com/v1",
         "http://169.254.169.254/latest/meta-data",  # metadata IP
         "https://modal.run.attacker.com/v1",  # suffix spoof
+        "https://attacker.fireworks.ai/inference/v1",
         "http://my-policy.modal.run/v1",  # remote must be https
         "ftp://localhost/v1",
     ],
@@ -95,6 +96,15 @@ def test_validate_endpoint_allows_controlled_hosts(api_base: str) -> None:
 def test_validate_endpoint_rejects_everything_else(api_base: str) -> None:
     with pytest.raises(ValueError):
         tito_capture.validate_endpoint(api_base)
+
+
+def test_validate_endpoint_enforces_configured_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERCOR_POLICY_ALLOWED_ORIGIN", "https://expected.modal.run")
+    tito_capture.validate_endpoint("https://expected.modal.run/v1")
+    with pytest.raises(ValueError, match="configured origin"):
+        tito_capture.validate_endpoint("https://other.modal.run/v1")
 
 
 def test_policy_model_name_strips_only_routing_prefixes() -> None:

--- a/agents/tests/test_tito_capture.py
+++ b/agents/tests/test_tito_capture.py
@@ -1,0 +1,285 @@
+"""Token-in transport + extraction tests for flat TITO capture (no network)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from runner.utils import tito_capture
+
+
+def _resp(
+    *,
+    resp_ids: list[int] | None,
+    token_logprobs: list[Any] | None,  # list[Any] so the null-logprob case type-checks
+    use_psf: bool = False,
+) -> Any:
+    if use_psf:
+        choice = SimpleNamespace(
+            provider_specific_fields={"token_ids": resp_ids},
+            logprobs=SimpleNamespace(token_logprobs=token_logprobs),
+        )
+    else:
+        choice = SimpleNamespace(
+            provider_specific_fields=None,
+            token_ids=resp_ids,
+            logprobs=SimpleNamespace(token_logprobs=token_logprobs),
+        )
+    return SimpleNamespace(choices=[choice])
+
+
+def test_extract_reads_token_ids_and_logprobs() -> None:
+    resp_ids, logprobs = tito_capture.extract_tokens(
+        _resp(resp_ids=[4, 5], token_logprobs=[-0.1, -0.2])
+    )
+    assert resp_ids == [4, 5]
+    assert logprobs == [-0.1, -0.2]
+
+
+def test_extract_reads_from_provider_specific_fields() -> None:
+    resp_ids, _ = tito_capture.extract_tokens(
+        _resp(resp_ids=[9], token_logprobs=[-0.3], use_psf=True)
+    )
+    assert resp_ids == [9]
+
+
+def test_extract_no_token_ids_fails_loud() -> None:
+    with pytest.raises(RuntimeError, match="capture-capable"):
+        tito_capture.extract_tokens(_resp(resp_ids=None, token_logprobs=None))
+
+
+def test_extract_misaligned_logprobs_fails_loud() -> None:
+    with pytest.raises(RuntimeError, match="logprobs unusable"):
+        tito_capture.extract_tokens(_resp(resp_ids=[4, 5], token_logprobs=[-0.1]))
+
+
+def test_extract_null_logprobs_fails_loud() -> None:
+    with pytest.raises(RuntimeError, match="null"):
+        tito_capture.extract_tokens(_resp(resp_ids=[4], token_logprobs=[None]))
+
+
+def test_extract_allows_empty_completion() -> None:
+    resp_ids, logprobs = tito_capture.extract_tokens(
+        _resp(resp_ids=[], token_logprobs=[])
+    )
+    assert resp_ids == []
+    assert logprobs == []
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "https://my-policy.modal.run/v1",
+        "https://acct-1.fireworks.ai/inference/v1",
+        "http://localhost:8000/v1",
+        "http://127.0.0.1:8000/v1",
+    ],
+)
+def test_validate_endpoint_allows_controlled_hosts(api_base: str) -> None:
+    tito_capture.validate_endpoint(api_base)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "https://evil.com/v1",
+        "http://169.254.169.254/latest/meta-data",  # metadata IP
+        "https://modal.run.attacker.com/v1",  # suffix spoof
+        "http://my-policy.modal.run/v1",  # remote must be https
+        "ftp://localhost/v1",
+    ],
+)
+def test_validate_endpoint_rejects_everything_else(api_base: str) -> None:
+    with pytest.raises(ValueError):
+        tito_capture.validate_endpoint(api_base)
+
+
+def test_policy_model_name_strips_only_routing_prefixes() -> None:
+    assert tito_capture._policy_model_name("fireworks_ai/qwen3-8b") == "qwen3-8b"
+    assert tito_capture._policy_model_name("hosted_vllm/Qwen/Qwen3-8B") == (
+        "Qwen/Qwen3-8B"
+    )
+    assert tito_capture._policy_model_name("openai/gpt-oss-20b") == (
+        "openai/gpt-oss-20b"
+    )
+    assert tito_capture._policy_model_name("policy") == "policy"
+
+
+def test_policy_model_name_strips_all_routing_prefixes() -> None:
+    assert (
+        tito_capture._policy_model_name("fireworks_ai/hosted_vllm/Qwen/Qwen3-8B")
+        == "Qwen/Qwen3-8B"
+    )
+
+
+async def test_generate_tokens_feeds_ids_and_forces_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _fake(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _resp(resp_ids=[7, 8], token_logprobs=[-0.1, -0.2])
+
+    monkeypatch.setattr(tito_capture, "_request_completion", _fake)
+
+    result = await tito_capture.generate_tokens(
+        model="fireworks_ai/qwen3-8b",
+        prompt_token_ids=[1, 2, 3],
+        sampling_args={
+            "temperature": 0.7,
+            "max_tokens": 128,
+            # Reserved keys the harness must not be able to override:
+            "logprobs": 99,
+            "return_token_ids": False,
+            "prompt": [999],
+            "timeout": 5,  # harness timeout must not collide with our explicit one
+        },
+        api_base="https://my-policy.modal.run/v1",
+        api_key="secret",
+        timeout=30,
+    )
+
+    assert result.completion_token_ids == [7, 8]
+    assert result.token_logprobs == [-0.1, -0.2]
+    assert captured["model"] == "qwen3-8b"
+    assert captured["prompt_token_ids"] == [1, 2, 3]
+    assert captured["api_base"] == "https://my-policy.modal.run/v1"
+    assert captured["sampling_args"] == {"temperature": 0.7, "max_tokens": 128}
+    assert captured["timeout"] == 30  # our explicit timeout, not the harness's 5
+
+
+async def test_request_completion_sends_extensions_via_extra_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    client_kwargs: dict[str, Any] = {}
+    response = _resp(resp_ids=[2], token_logprobs=[-0.1])
+
+    class RawResponse:
+        def parse(self) -> Any:
+            return response
+
+    class WithRawResponse:
+        async def create(self, **kwargs: Any) -> RawResponse:
+            captured.update(kwargs)
+            return RawResponse()
+
+    class Completions:
+        with_raw_response = WithRawResponse()
+
+    class Client:
+        completions = Completions()
+
+    def _client(**kwargs: Any) -> Client:
+        client_kwargs.update(kwargs)
+        return Client()
+
+    monkeypatch.setattr(tito_capture, "AsyncOpenAI", _client)
+    await tito_capture._request_completion(
+        model="Qwen/Qwen3-8B",
+        prompt_token_ids=[1],
+        sampling_args={"max_tokens": 8},
+        api_base="https://policy.modal.run/v1",
+        api_key="secret",
+        timeout=30,
+    )
+    assert captured["prompt"] == [1]
+    assert captured["extra_body"] == {"return_token_ids": True}
+    assert captured["max_tokens"] == 8
+    assert client_kwargs["http_client"].follow_redirects is False
+
+
+async def test_generate_tokens_rejects_routing_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unexpected(**_: Any) -> Any:
+        raise AssertionError("transport must not run")
+
+    monkeypatch.setattr(tito_capture, "_request_completion", _unexpected)
+    with pytest.raises(ValueError, match="unsupported TITO sampling argument"):
+        await tito_capture.generate_tokens(
+            model="fireworks_ai/qwen3-8b",
+            prompt_token_ids=[1],
+            sampling_args={"base_url": "https://attacker.example/v1"},
+            api_base="https://my-policy.modal.run/v1",
+            api_key="secret",
+            timeout=30,
+        )
+
+
+async def test_generate_tokens_validates_prompt_before_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unexpected(**_: Any) -> Any:
+        raise AssertionError("transport must not run")
+
+    monkeypatch.setattr(tito_capture, "_request_completion", _unexpected)
+    with pytest.raises(RuntimeError, match="prompt token IDs"):
+        await tito_capture.generate_tokens(
+            model="qwen",
+            prompt_token_ids=[True],
+            sampling_args={},
+            api_base="https://policy.modal.run/v1",
+            api_key="secret",
+            timeout=30,
+        )
+
+
+def test_logit_bias_rejects_lossy_or_boolean_token_ids() -> None:
+    with pytest.raises(ValueError, match="token IDs"):
+        tito_capture._validated_sampling_args({"logit_bias": {True: 1}})
+    with pytest.raises(ValueError, match="token IDs"):
+        tito_capture._validated_sampling_args({"logit_bias": {1.2: 1}})
+
+
+def test_extract_realistic_fireworks_completion_model() -> None:
+    from openai.types.completion import Completion
+
+    response = Completion.model_validate(
+        {
+            "id": "fw-1",
+            "object": "text_completion",
+            "created": 1,
+            "model": "accounts/a/models/qwen",
+            "prompt_token_ids": [1, 2],
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "x",
+                    "finish_reason": "stop",
+                    "logprobs": {
+                        "tokens": ["x"],
+                        "token_logprobs": [-0.2],
+                        "top_logprobs": [{}],
+                        "text_offset": [0],
+                        "token_ids": [7],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+        }
+    )
+    round_tripped = Completion.model_validate_json(json.dumps(response.model_dump()))
+    result = tito_capture.extract_completion(round_tripped, prompt_token_ids=[1, 2])
+    assert result.completion_token_ids == [7]
+    assert result.token_logprobs == [-0.2]
+
+
+def test_extract_reads_fireworks_logprobs_token_ids() -> None:
+    choice = SimpleNamespace(
+        provider_specific_fields=None,
+        token_ids=None,
+        finish_reason="length",
+        text="x",
+        logprobs=SimpleNamespace(token_ids=[7], token_logprobs=[-0.4]),
+    )
+    result = tito_capture.extract_completion(
+        SimpleNamespace(choices=[choice], usage=None), prompt_token_ids=[1, 2]
+    )
+    assert result.completion_token_ids == [7]
+    assert result.token_logprobs == [-0.4]
+    assert result.finish_reason == "length"

--- a/agents/tests/test_tito_renderer.py
+++ b/agents/tests/test_tito_renderer.py
@@ -1,0 +1,114 @@
+"""Pure resolution-helper tests for tito_renderer (no transformers/renderers)."""
+
+from __future__ import annotations
+
+import pytest
+
+from runner.utils import tito_renderer
+
+
+def test_resolve_hf_id_strips_provider_prefixes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MERCOR_POLICY_HF_ID", raising=False)
+    assert tito_renderer.resolve_hf_id("hosted_vllm/Qwen/Qwen3-8B") == "Qwen/Qwen3-8B"
+    assert tito_renderer.resolve_hf_id("responses/openai/Qwen/Qwen3-4B") == (
+        "Qwen/Qwen3-4B"
+    )
+
+
+def test_resolve_hf_id_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MERCOR_POLICY_HF_ID", "Qwen/Qwen3-32B")
+    assert tito_renderer.resolve_hf_id("fireworks_ai/qwen3p6-27b") == "Qwen/Qwen3-32B"
+
+
+def test_is_default_renderer_detects_generic_fallback() -> None:
+    class DefaultRenderer:  # name matches renderers' generic fallback
+        pass
+
+    class Qwen3Renderer:
+        pass
+
+    assert tito_renderer._is_default_renderer(DefaultRenderer())
+    assert not tito_renderer._is_default_renderer(Qwen3Renderer())
+
+
+def test_validate_hf_id_rejects_default_renderer_fallback() -> None:
+    with pytest.raises(RuntimeError, match="exact text-only model"):
+        tito_renderer.validate_hf_id("some-org/unregistered-fine-tune")
+
+
+def test_as_ids_accepts_list_and_rendered_tokens() -> None:
+    from types import SimpleNamespace
+
+    # render_ids returns a plain list; bridge_to_next_turn returns a
+    # RenderedTokens object exposing .token_ids — accept both.
+    assert tito_renderer._as_ids([1, 2, 3]) == [1, 2, 3]
+    assert tito_renderer._as_ids(SimpleNamespace(token_ids=[4, 5])) == [4, 5]
+
+
+def test_registered_text_models_are_exact_and_exclude_multimodal() -> None:
+    supported = tito_renderer.registered_text_model_ids()
+    assert "Qwen/Qwen3-8B" in supported
+    assert "moonshotai/Kimi-K2-Instruct" in supported
+    assert "openai/gpt-oss-20b" in supported
+    assert "Qwen/Qwen3-VL-8B-Instruct" not in supported
+    assert "Qwen/Qwen3.5-9B" not in supported
+    assert len(supported) == 39
+
+
+def test_wrapper_preserves_explicit_empty_tools() -> None:
+    class FakeRenderer:
+        def __init__(self) -> None:
+            self.seen: list[object] = []
+
+        def render(self, messages, *, tools=None, add_generation_prompt=False):
+            from types import SimpleNamespace
+
+            self.seen.append(tools)
+            return SimpleNamespace(token_ids=[1], multi_modal_data=None)
+
+        def bridge_to_next_turn(self, prompt, completion, messages, *, tools=None):
+            from types import SimpleNamespace
+
+            self.seen.append(tools)
+            return SimpleNamespace(
+                token_ids=[*prompt, *completion, 2], multi_modal_data=None
+            )
+
+        def parse_response(self, completion, *, tools=None):
+            from types import SimpleNamespace
+
+            self.seen.append(tools)
+            return SimpleNamespace(content="ok", reasoning_content=None, tool_calls=[])
+
+    wrapper = object.__new__(tito_renderer.TitoRenderer)
+    fake = FakeRenderer()
+    wrapper.hf_id = "Qwen/Qwen3-8B"
+    wrapper.chat_template_kwargs = {}
+    wrapper._renderer = fake
+    assert wrapper.render_ids([{"role": "user", "content": "hi"}], []) == [1]
+    assert wrapper.bridge([1], [2], [{"role": "tool", "content": "x"}], []) == [
+        1,
+        2,
+        2,
+    ]
+    wrapper.parse([3], [])
+    assert fake.seen == [[], [], []]
+
+
+def test_normalize_messages_flattens_text_parts_and_rejects_media() -> None:
+    assert tito_renderer.normalize_messages(
+        [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+    ) == [{"role": "user", "content": "hello"}]
+    with pytest.raises(ValueError, match="text-only"):
+        tito_renderer.normalize_messages(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "data:image/png"}}
+                    ],
+                }
+            ]
+        )

--- a/agents/tests/test_tito_session.py
+++ b/agents/tests/test_tito_session.py
@@ -293,6 +293,45 @@ async def test_responses_facade_uses_shared_parsed_sample(
     assert [item["type"] for item in response.output] == ["reasoning", "message"]
 
 
+def test_responses_normalization_does_not_mutate_tool_calls() -> None:
+    existing = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "first", "arguments": "{}"},
+            }
+        ],
+    }
+    messages = [
+        existing,
+        {
+            "type": "function_call",
+            "call_id": "call_2",
+            "name": "second",
+            "arguments": "{}",
+        },
+    ]
+    normalized = tito_session._normalize_responses_messages(messages)
+    assert len(existing["tool_calls"]) == 1
+    assert len(normalized[0]["tool_calls"]) == 2
+
+
+def test_responses_normalization_accepts_emitted_reasoning_items() -> None:
+    normalized = tito_session._normalize_responses_messages(
+        [
+            {
+                "type": "reasoning",
+                "content": [{"type": "reasoning_text", "text": "why"}],
+                "summary": [{"type": "summary_text", "text": "why"}],
+            },
+            {"role": "assistant", "content": "answer"},
+        ]
+    )
+    assert normalized == [{"role": "assistant", "content": "answer"}]
+
+
 async def test_responses_reasoning_and_tool_echo_remains_linear(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/agents/tests/test_tito_session.py
+++ b/agents/tests/test_tito_session.py
@@ -1,0 +1,510 @@
+"""Buffer state machine + env gate tests for flat TITO capture.
+
+Uses a fake renderer and a mocked token-in transport — no network, no tokenizer
+download, no renderers/transformers import.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from runner.utils import llm, tito_capture, tito_renderer, tito_session
+
+_API_BASE = "https://my-policy.modal.run/v1"
+
+
+class _FakeRenderer:
+    """Deterministic stand-in for TitoRenderer.
+
+    ``render_ids`` returns a fixed first prompt; ``bridge`` extends
+    (prev_prompt + prev_completion) with the next delta, or ``None`` when
+    ``bridge_none`` is set (simulating a non-append-only turn).
+    """
+
+    def __init__(
+        self,
+        prompt1: list[int],
+        deltas: list[list[int]],
+        parsed: Any,
+        parse_errors: list[str] | None = None,
+    ):
+        self.prompt1 = prompt1
+        self.deltas = list(deltas)
+        self.parsed = parsed
+        self.parse_errors = list(parse_errors or [])
+        self.bridge_none = False
+
+    def render_ids(self, messages: Any, tools: Any) -> list[int]:
+        return list(self.prompt1)
+
+    def bridge(
+        self, prev_p: list[int], prev_c: list[int], new_msgs: Any, tools: Any
+    ) -> list[int] | None:
+        if self.bridge_none:
+            return None
+        return list(prev_p) + list(prev_c) + list(self.deltas.pop(0))
+
+    def parse(
+        self, resp_ids: list[int], tools: Any = None
+    ) -> tito_renderer.TitoParsedResponse:
+        content, reasoning, calls = self.parsed
+        parsed_calls: list[tito_renderer.TitoParsedToolCall] = []
+        for call in calls or []:
+            function = call.get("function", call)
+            parsed_calls.append(
+                tito_renderer.TitoParsedToolCall(
+                    id=call.get("id"),
+                    name=function["name"],
+                    arguments=function.get("arguments"),
+                )
+            )
+        return tito_renderer.TitoParsedResponse(
+            content=content,
+            reasoning_content=reasoning,
+            tool_calls=parsed_calls,
+            parse_errors=self.parse_errors,
+        )
+
+
+def _session(renderer: _FakeRenderer) -> tito_session.TitoCaptureSession:
+    s = tito_session.TitoCaptureSession(
+        policy_model="fireworks_ai/qwen3-8b",
+        hf_id="Qwen/Qwen3-8B",
+        api_base=_API_BASE,
+        api_key="k",
+        default_max_tokens=8192,
+    )
+    # Inject the fake, skipping the real (network) renderer build. cast to Any
+    # keeps basedpyright happy (no invalid-cast); plain assignment keeps ruff B010.
+    s._renderer = cast(Any, renderer)
+    return s
+
+
+def _mock_transport(
+    monkeypatch: pytest.MonkeyPatch, results: list[tuple[list[int], list[float]]]
+) -> None:
+    it = iter(results)
+
+    async def _fake(**kwargs: Any) -> tito_capture.TokenCompletion:
+        response_ids, logprobs = next(it)
+        prompt_ids = list(kwargs["prompt_token_ids"])
+        return tito_capture.TokenCompletion(
+            prompt_token_ids=prompt_ids,
+            completion_token_ids=response_ids,
+            token_logprobs=logprobs,
+            text="",
+            finish_reason="stop",
+            native_finish_reason="stop",
+            usage={
+                "prompt_tokens": len(prompt_ids),
+                "completion_tokens": len(response_ids),
+                "total_tokens": len(prompt_ids) + len(response_ids),
+            },
+            request_id=None,
+            model=None,
+        )
+
+    monkeypatch.setattr(tito_capture, "generate_tokens", _fake)
+
+
+def _completion(
+    kwargs: dict[str, Any], response_ids: list[int], logprobs: list[float]
+) -> tito_capture.TokenCompletion:
+    prompt_ids = list(kwargs["prompt_token_ids"])
+    return tito_capture.TokenCompletion(
+        prompt_token_ids=prompt_ids,
+        completion_token_ids=response_ids,
+        token_logprobs=logprobs,
+        text="",
+        finish_reason="stop",
+        native_finish_reason="stop",
+        usage={
+            "prompt_tokens": len(prompt_ids),
+            "completion_tokens": len(response_ids),
+            "total_tokens": len(prompt_ids) + len(response_ids),
+        },
+        request_id=None,
+        model=None,
+    )
+
+
+# --- flat buffer assembly ---------------------------------------------------
+
+
+async def test_flat_buffer_across_turns(monkeypatch: pytest.MonkeyPatch) -> None:
+    renderer = _FakeRenderer(prompt1=[1, 2, 3], deltas=[[6]], parsed=("hi", None, None))
+    _mock_transport(monkeypatch, [([4, 5], [-0.1, -0.2]), ([7], [-0.3])])
+    s = _session(renderer)
+
+    first = [{"role": "user", "content": "m0"}]
+    await s.generate("fireworks_ai/qwen3-8b", first, None, {}, timeout=30)
+    # Harness echoes our assistant turn + a tool result before the next call.
+    await s.generate(
+        "fireworks_ai/qwen3-8b",
+        [
+            *first,
+            {"role": "assistant", "content": "hi"},
+            {"role": "tool", "content": "tool1"},
+        ],
+        None,
+        {},
+        timeout=30,
+    )
+
+    out = s.output_dict()
+    assert out["tito_version"] == 1
+    assert out["tito_complete"] is True
+    assert out["token_ids"] == [1, 2, 3, 4, 5, 6, 7]
+    # loss_mask=1 only on sampled tokens (4,5 and 7); prompt+bridge are 0.
+    assert out["loss_mask"] == [0, 0, 0, 1, 1, 0, 1]
+    assert out["logprobs"] == [0.0, 0.0, 0.0, -0.1, -0.2, 0.0, -0.3]
+
+
+async def test_non_append_only_marks_incomplete_and_stops_buffering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    renderer = _FakeRenderer(prompt1=[1, 2, 3], deltas=[], parsed=("hi", None, None))
+    _mock_transport(monkeypatch, [([4, 5], [-0.1, -0.2]), ([7], [-0.3])])
+    s = _session(renderer)
+
+    await s.generate("fireworks_ai/qwen3-8b", ["m0"], None, {}, timeout=30)
+    renderer.bridge_none = True  # next turn can't be safely extended
+    await s.generate(
+        "fireworks_ai/qwen3-8b", ["m0", "assistant1", "tool1"], None, {}, timeout=30
+    )
+
+    out = s.output_dict()
+    assert out["tito_complete"] is False
+    assert out["tito_error"]
+    # Buffer frozen at turn 1 — never fabricated past the break.
+    assert out["token_ids"] == [1, 2, 3, 4, 5]
+    assert out["loss_mask"] == [0, 0, 0, 1, 1]
+
+
+async def test_history_shrink_marks_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    renderer = _FakeRenderer(prompt1=[1, 2, 3], deltas=[], parsed=("hi", None, None))
+    _mock_transport(monkeypatch, [([4, 5], [-0.1, -0.2]), ([7], [-0.3])])
+    s = _session(renderer)
+    await s.generate("fireworks_ai/qwen3-8b", ["a", "b", "c"], None, {}, timeout=30)
+    # Message list shrank (a summarizer rewrote history) — not a safe extension.
+    await s.generate("fireworks_ai/qwen3-8b", ["short"], None, {}, timeout=30)
+    assert s.output_dict()["tito_complete"] is False
+
+
+async def test_transient_request_suffix_cannot_skip_a_real_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    renderer = _FakeRenderer(prompt1=[1, 2, 3], deltas=[[6]], parsed=("hi", None, None))
+    _mock_transport(monkeypatch, [([4, 5], [-0.1, -0.2]), ([7], [-0.3])])
+    s = _session(renderer)
+    first = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "u"},
+        {"role": "user", "content": "transient-1"},
+    ]
+    await s.generate("fireworks_ai/qwen3-8b", first, None, {}, timeout=30)
+    second = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "tool", "content": "real-result"},
+        {"role": "user", "content": "transient-2"},
+    ]
+    await s.generate("fireworks_ai/qwen3-8b", second, None, {}, timeout=30)
+    assert s.output_dict()["tito_complete"] is False
+
+
+async def test_response_contains_exact_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    renderer = _FakeRenderer(prompt1=[1, 2, 3], deltas=[], parsed=("hi", None, None))
+    _mock_transport(monkeypatch, [([4, 5], [-0.1, -0.2])])
+    response = await _session(renderer).generate(
+        "fireworks_ai/qwen3-8b", [{"role": "user", "content": "hi"}], None, {}, 30
+    )
+    usage = getattr(response, "usage", None)
+    assert usage is not None
+    assert usage.prompt_tokens == 3
+    assert usage.completion_tokens == 2
+
+
+async def test_concurrent_calls_freeze_without_interleaving(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    renderer = _FakeRenderer(prompt1=[1], deltas=[], parsed=("hi", None, None))
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def _fake(**kwargs: Any) -> tito_capture.TokenCompletion:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            entered.set()
+            await release.wait()
+        return _completion(kwargs, [calls + 1], [-0.1])
+
+    monkeypatch.setattr(tito_capture, "generate_tokens", _fake)
+    s = _session(renderer)
+    first = asyncio.create_task(
+        s.generate(
+            "fireworks_ai/qwen3-8b",
+            [{"role": "user", "content": "first"}],
+            None,
+            {},
+            30,
+        )
+    )
+    await entered.wait()
+    second = asyncio.create_task(
+        s.generate(
+            "fireworks_ai/qwen3-8b",
+            [{"role": "user", "content": "second"}],
+            None,
+            {},
+            30,
+        )
+    )
+    release.set()
+    await asyncio.gather(first, second)
+    out = s.output_dict()
+    assert out["tito_complete"] is False
+    assert out["token_ids"] == [1, 2]
+
+
+async def test_responses_facade_uses_shared_parsed_sample(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    renderer = _FakeRenderer(prompt1=[1, 2], deltas=[], parsed=("hello", "why", None))
+    _mock_transport(monkeypatch, [([3], [-0.2])])
+    response = await _session(renderer).generate_responses(
+        "fireworks_ai/qwen3-8b",
+        [{"role": "developer", "content": "system"}, {"role": "user", "content": "hi"}],
+        [],
+        {},
+        30,
+    )
+    assert response.status == "completed"
+    assert response.usage.input_tokens == 2
+    assert response.usage.output_tokens == 1
+    assert [item["type"] for item in response.output] == ["reasoning", "message"]
+
+
+async def test_responses_reasoning_and_tool_echo_remains_linear(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = [{"id": "call_1", "function": {"name": "search", "arguments": {"q": "x"}}}]
+    renderer = _FakeRenderer(prompt1=[1, 2], deltas=[[5]], parsed=(None, "why", calls))
+    _mock_transport(monkeypatch, [([3, 4], [-0.1, -0.2]), ([6], [-0.3])])
+    session = _session(renderer)
+    first_messages = [
+        {"role": "developer", "content": "system"},
+        {"role": "user", "content": "hi"},
+    ]
+    first = await session.generate_responses(
+        "fireworks_ai/qwen3-8b", first_messages, [], {}, 30
+    )
+    function_call = next(
+        item for item in first.output if item["type"] == "function_call"
+    )
+    next_input = [
+        {"role": "developer", "content": "system"},
+        {"role": "user", "content": "hi"},
+        {
+            "type": "function_call",
+            "id": function_call["id"],
+            "call_id": function_call["call_id"],
+            "name": function_call["name"],
+            "arguments": function_call["arguments"],
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "result",
+        },
+    ]
+    await session.generate_responses("fireworks_ai/qwen3-8b", next_input, [], {}, 30)
+    assert session.output_dict()["tito_complete"] is True
+
+
+async def test_central_responses_path_diverts_to_active_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    renderer = _FakeRenderer(prompt1=[1], deltas=[], parsed=("hello", None, None))
+    _mock_transport(monkeypatch, [([2], [-0.1])])
+    session = _session(renderer)
+    token = tito_session.set_active_session(session)
+
+    async def _unexpected(**_: Any) -> Any:
+        raise AssertionError("native Responses transport must not run")
+
+    monkeypatch.setattr(llm, "aresponses", _unexpected)
+    try:
+        response = await llm.call_responses_api(
+            "fireworks_ai/qwen3-8b",
+            [{"role": "user", "content": "hi"}],
+            [],
+            30,
+            {},
+            stream=True,
+        )
+    finally:
+        tito_session.reset_active_session(token)
+    assert response.output[0]["content"][0]["text"] == "hello"
+    assert tito_session.get_active_session() is None
+
+
+async def test_parse_ambiguity_freezes_after_recording_exact_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    renderer = _FakeRenderer(
+        prompt1=[1],
+        deltas=[],
+        parsed=("", None, None),
+        parse_errors=["invalid_json"],
+    )
+    _mock_transport(monkeypatch, [([2], [-0.1])])
+    session = _session(renderer)
+    await session.generate(
+        "fireworks_ai/qwen3-8b",
+        [{"role": "user", "content": "hi"}],
+        None,
+        {},
+        30,
+    )
+    out = session.output_dict()
+    assert out["token_ids"] == [1, 2]
+    assert out["tito_complete"] is False
+    assert "parse" in out["tito_error"]
+
+
+async def test_response_reconstructed_with_tool_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_calls = [{"id": "c1", "function": {"name": "search", "arguments": {"q": "x"}}}]
+    renderer = _FakeRenderer(
+        prompt1=[1], deltas=[], parsed=(None, "thinking", tool_calls)
+    )
+    _mock_transport(monkeypatch, [([2, 3], [-0.1, -0.2])])
+    s = _session(renderer)
+
+    resp = await s.generate("fireworks_ai/qwen3-8b", ["m0"], None, {}, timeout=30)
+    msg = resp.choices[0].message
+    assert resp.choices[0].finish_reason == "tool_calls"
+    assert msg.tool_calls is not None
+    assert msg.tool_calls[0].function.name == "search"
+    # arguments serialized to a JSON string.
+    assert msg.tool_calls[0].function.arguments == '{"q": "x"}'
+
+
+async def test_none_output_limit_uses_session_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _fake(**kwargs: Any) -> tito_capture.TokenCompletion:
+        seen.update(kwargs)
+        return _completion(kwargs, [2], [-0.1])
+
+    monkeypatch.setattr(tito_capture, "generate_tokens", _fake)
+    session = _session(_FakeRenderer(prompt1=[1], deltas=[], parsed=("hi", None, None)))
+    await session.generate(
+        "fireworks_ai/qwen3-8b",
+        [{"role": "user", "content": "hi"}],
+        None,
+        {"max_output_tokens": None},
+        30,
+    )
+    assert seen["sampling_args"]["max_tokens"] == 8192
+
+
+async def test_max_output_tokens_mapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _fake(**kwargs: Any) -> tito_capture.TokenCompletion:
+        seen.update(kwargs)
+        return _completion(kwargs, [2], [-0.1])
+
+    monkeypatch.setattr(tito_capture, "generate_tokens", _fake)
+    s = _session(_FakeRenderer(prompt1=[1], deltas=[], parsed=("hi", None, None)))
+    await s.generate(
+        "fireworks_ai/qwen3-8b", ["m0"], None, {"max_output_tokens": 123}, timeout=30
+    )
+    assert seen["sampling_args"]["max_tokens"] == 123
+    assert "max_output_tokens" not in seen["sampling_args"]
+
+
+# --- handles + output_dict edges -------------------------------------------
+
+
+def test_handles_gates_to_policy_model() -> None:
+    s = _session(_FakeRenderer([1], [], ("", None, None)))
+    assert s.handles("fireworks_ai/qwen3-8b")
+    assert s.handles("responses/fireworks_ai/qwen3-8b")
+    assert not s.handles("anthropic/claude-helper")
+
+
+def test_output_dict_marks_no_call_incomplete() -> None:
+    s = _session(_FakeRenderer([1], [], ("", None, None)))
+    assert s.output_dict()["tito_complete"] is False
+    assert "no matching" in s.output_dict()["tito_error"]
+
+
+def test_nest_in_output_preserves_harness_keys() -> None:
+    tito_payload = {
+        "tito_version": 1,
+        "tito_complete": True,
+        "token_ids": [1, 2],
+        "loss_mask": [0, 1],
+        "logprobs": [0.0, -0.1],
+    }
+    merged = tito_session.nest_in_output({"harness_key": "keep"}, tito_payload)
+    assert merged["harness_key"] == "keep"
+    assert merged["tito"] == tito_payload
+    assert "token_ids" not in merged
+
+
+def test_nest_in_output_handles_none_harness_output() -> None:
+    merged = tito_session.nest_in_output(
+        None, {"tito_version": 1, "tito_complete": False}
+    )
+    assert merged == {"tito": {"tito_version": 1, "tito_complete": False}}
+
+
+# --- tool-call adapter ------------------------------------------------------
+
+
+def test_tool_calls_adapter_serializes_parsed_calls() -> None:
+    calls = [tito_renderer.TitoParsedToolCall(id=None, name="f", arguments={"a": 1})]
+    converted = tito_session._tool_calls_to_dicts(calls)
+    assert converted and converted[0]["id"]
+    assert converted[0]["function"] == {"name": "f", "arguments": '{"a": 1}'}
+    assert tito_session._tool_calls_to_dicts([]) is None
+
+
+# --- env gate + family resolution ------------------------------------------
+
+
+def test_session_from_env_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MERCOR_TITO_CAPTURE", raising=False)
+    assert tito_session.session_from_env(policy_model="Qwen/Qwen3-8B") is None
+
+
+def test_session_from_env_requires_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MERCOR_TITO_CAPTURE", "true")
+    monkeypatch.delenv("MERCOR_POLICY_API_BASE", raising=False)
+    with pytest.raises(RuntimeError, match="MERCOR_POLICY_API_BASE"):
+        tito_session.session_from_env(policy_model="Qwen/Qwen3-8B")
+
+
+def test_session_from_env_requires_registered_text_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERCOR_TITO_CAPTURE", "true")
+    monkeypatch.setenv("MERCOR_POLICY_API_BASE", _API_BASE)
+    monkeypatch.delenv("MERCOR_POLICY_HF_ID", raising=False)
+    with pytest.raises(RuntimeError, match="exact text-only model"):
+        tito_session.session_from_env(policy_model="meta-llama/Llama-3.1-8B")

--- a/agents/uv.lock
+++ b/agents/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-31T01:20:25.618871Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -209,6 +209,7 @@ dependencies = [
     { name = "pymupdf" },
     { name = "python-docx" },
     { name = "redis" },
+    { name = "renderers" },
     { name = "tenacity" },
     { name = "trafilatura" },
 ]
@@ -248,6 +249,7 @@ requires-dist = [
     { name = "pymupdf", specifier = ">=1.27.2" },
     { name = "python-docx", specifier = ">=1.1.0" },
     { name = "redis", specifier = ">=6.4.0" },
+    { name = "renderers", specifier = "==0.1.8" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "trafilatura", specifier = ">=1.12.0" },
 ]
@@ -453,14 +455,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -945,24 +947,18 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
 ]
 
 [[package]]
@@ -1034,23 +1030,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.1.7"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "shellingham" },
     { name = "tqdm" },
-    { name = "typer-slim" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/fa/a1a94c55637f2b7cfeb05263ac3881aa87c82df92d8b4b31c909079f4419/huggingface_hub-1.1.7.tar.gz", hash = "sha256:3c84b6283caca928595f08fd42e9a572f17ec3501dec508c3f2939d94bfbd9d2", size = 607537, upload-time = "2025-12-01T11:05:28.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/4f/82e5ab009089a2c48472bf4248391fe4091cf0b9c3e951dbb8afe3b23d76/huggingface_hub-1.1.7-py3-none-any.whl", hash = "sha256:f3efa4779f4890e44c957bbbb0f197e6028887ad09f0cf95a21659fa7753605d", size = 516239, upload-time = "2025-12-01T11:05:25.981Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
 ]
 
 [[package]]
@@ -1520,6 +1515,25 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1536,6 +1550,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+]
+
+[[package]]
+name = "openai-harmony"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/c6/2502f416d46be3ec08bb66d696cccffb57781a499e3ff2e4d7c174af4e8f/openai_harmony-0.0.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:029ec25ca74abe48fdb58eb9fdd2a8c1618581fc33ce8e5653f8a1ffbfbd9326", size = 2627806, upload-time = "2025-11-05T19:06:57.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d2/ce6953ca87db9cae3e775024184da7d1c5cb88cead19a2d75b42f00a959c/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4f709815924ec325b9a890e6ab2bbb0ceec8e319a4e257328eb752cf36b2efc", size = 2948463, upload-time = "2025-11-05T19:06:48.17Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4c/b553c9651662d6ce102ca7f3629d268b23df1abe5841e24bed81e8a8e949/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5cfcfd963b50a41fc656c84d3440ca6eecdccd6c552158ce790b8f2e33dfb5a9", size = 2704083, upload-time = "2025-11-05T19:06:50.205Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/af/4eec8f9ab9c27bcdb444460c72cf43011d176fc44c79d6e113094ca1e152/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a3a16972aa1cee38ea958470cd04ac9a2d5ac38fdcf77ab686611246220c158", size = 2959765, upload-time = "2025-11-05T19:06:53.62Z" },
+    { url = "https://files.pythonhosted.org/packages/11/3c/33f3374e4624e0e776f6b13b73c45a7ead7f9c4529f8369ed5bfcaa30cac/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4d5cfa168e74d08f8ba6d58a7e49bc7daef4d58951ec69b66b0d56f4927a68d", size = 3427031, upload-time = "2025-11-05T19:06:51.829Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3f/1a192b93bb47c6b44cd98ba8cc1d3d2a9308f1bb700c3017e6352da11bda/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c007d277218a50db8839e599ed78e0fffe5130f614c3f6d93ae257f282071a29", size = 2953260, upload-time = "2025-11-05T19:06:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/93b582cad3531797c3db7c2db5400fd841538ccddfd9f5e3df61be99a630/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8565d4f5a0638da1bffde29832ed63c9e695c558611053add3b2dc0b56c92dbc", size = 3127044, upload-time = "2025-11-05T19:06:59.553Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/10/4327dbf87f75ae813405fd9a9b4a5cde63d506ffed0a096a440a4cabd89c/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:cbaa3bda75ef0d8836e1f8cc84af62f971b1d756d740efc95c38c3e04c0bfde2", size = 2932931, upload-time = "2025-11-05T19:07:01.437Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c8/1774eec4f6f360ef57618fb8f52e3d3af245b2491bd0297513aa09eec04b/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:772922a9bd24e133950fad71eb1550836f415a88e8c77870e12d0c3bd688ddc2", size = 2996140, upload-time = "2025-11-05T19:07:03.438Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c3/3d1e01e2dba517a91760e4a03e4f20ffc75039a6fe584d0e6f9b5c78fd15/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:007b0476a1f331f8130783f901f1da6f5a7057af1a4891f1b6a31dec364189b5", size = 3205080, upload-time = "2025-11-05T19:07:05.078Z" },
+    { url = "https://files.pythonhosted.org/packages/14/63/119de431572d7c70a7bf1037034a9be6ed0a7502a7498ba7302bca5b3242/openai_harmony-0.0.8-cp38-abi3-win32.whl", hash = "sha256:a9b5f893326b28d9e935ade14b4f655f5a840942473bc89b201c25f7a15af9cf", size = 2082457, upload-time = "2025-11-05T19:07:09.631Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/c83cf5a206c263ee70448a5ae4264682555f4d0b5bed0d2cc6ca1108103d/openai_harmony-0.0.8-cp38-abi3-win_amd64.whl", hash = "sha256:39d44f0d8f466bd56698e7ead708bead3141e27b9b87e3ab7d5a6d0e4a869ee5", size = 2438369, upload-time = "2025-11-05T19:07:08.1Z" },
 ]
 
 [[package]]
@@ -1666,6 +1703,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/3e/41909586cb148db0259e0208310067afda4cc097f4c7a779e829c1e68c46/postgrest-2.31.0-py3-none-any.whl", hash = "sha256:c2fd47c94e13ee8335111c4f03c9a24ea9766ce9d35fc3cd7330057c9e7ea0c3", size = 23098, upload-time = "2026-06-04T13:37:19.452Z" },
+]
+
+[[package]]
+name = "prime-pydantic-config"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/37/e240dd598e687af74523f4497acb122b6d484975dac35e38932b58733753/prime_pydantic_config-0.4.2.tar.gz", hash = "sha256:7e85ac624c63edc1995ef512398fa5cd4610724b48a65c595f7742b7514153a4", size = 75997, upload-time = "2026-07-20T19:39:54.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/f7/12d3b54d0db5812d4fb9e8b9df987f805e687df2f0d11359c2d066df513c/prime_pydantic_config-0.4.2-py3-none-any.whl", hash = "sha256:092f7da638f625747a136983b579f5c929ead1b243df22f69fad6cf16b044ab0", size = 27414, upload-time = "2026-07-20T19:39:53.716Z" },
 ]
 
 [[package]]
@@ -2099,6 +2148,24 @@ wheels = [
 ]
 
 [[package]]
+name = "renderers"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "openai-harmony" },
+    { name = "prime-pydantic-config" },
+    { name = "tiktoken" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/82/e493c5f6752283b18f43b8bb3e6f3b2068310a0a42b0650de1b841713fa3/renderers-0.1.8.tar.gz", hash = "sha256:7a50b59cc64593da504c054bf3e2f0f147af5c1770bad7107de7b18887377280", size = 343291, upload-time = "2026-07-15T14:10:22.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/2b/6defb0cc5ca19d66798a6c656d30aab86d7c9d4cec14c2b24248b5421c86/renderers-0.1.8-py3-none-any.whl", hash = "sha256:40e6b2c766e23feb12f73b1fbdfef4dea51921479454756ac796612e3bef8397", size = 189915, upload-time = "2026-07-15T14:10:21.371Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2224,6 +2291,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [[package]]
@@ -2520,6 +2611,26 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "5.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/2a2ba88f325e68a921d8b69ff63b477830b2e73ade9a3c8c8cab2f06d741/transformers-5.14.1.tar.gz", hash = "sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173", size = 9295927, upload-time = "2026-07-16T09:41:57.773Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/67/8d85ca2323233ae3c0365a659c4e52ee1f587b440e4bc577e7d8e4416d0f/transformers-5.14.1-py3-none-any.whl", hash = "sha256:9db974c4079ede2d1a3ea7ca5a240df33f2cc26fc2b36ba64c5f2a4f43b6e725", size = 11625234, upload-time = "2026-07-16T09:41:54.143Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.26.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2532,19 +2643,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/45/81b94a52caed434b94da65729c03ad0fb7665fab0f7db9ee54c94e541403/typer_slim-0.20.0.tar.gz", hash = "sha256:9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3", size = 106561, upload-time = "2025-10-20T17:03:46.642Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/dd/5cbf31f402f1cc0ab087c94d4669cfa55bd1e818688b910631e131d74e75/typer_slim-0.20.0-py3-none-any.whl", hash = "sha256:f42a9b7571a12b97dddf364745d29f12221865acef7a2680065f9bb29c7dc89d", size = 47087, upload-time = "2025-10-20T17:03:44.546Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- capture exact policy prompt/response token IDs and logprobs at shared Chat and Responses LLM chokepoints
- use pinned, exact text-only renderers and freeze the flat tape whenever append-only lineage cannot be proven
- use a dedicated redirect-disabled token transport with strict endpoint, sampling, and response validation
- round-trip emitted Responses reasoning without mutating caller-owned message history
- emit the default-off nested `output.tito` v1 contract consumed by the paired `mercor-skyrl` PR

## Consumer
- Mercor-Intelligence/mercor-skyrl#14
- consumer pins commit `5dcabde5f53c6a938cfc3cdf7e62be2c91040074`

#### Test plan
- [x] `uv lock --check`
- [x] focused Ruff check and format check for all changed files
- [x] `PYTHONPATH=. uv run basedpyright` (0 errors)
- [x] `PYTHONPATH=. uv run pytest tests/ -n 16 -q` (55 passed)
- [x] cross-repo producer → `mercor-skyrl` parser → real SkyRL `validate_generator_output`
- [x] clean unauthenticated fetch of the pinned SHA
- [ ] live Fireworks one-step GRPO smoke (paired PR, running)

Generated with [Devin](https://devin.ai)